### PR TITLE
Add stop cmd for Pulsar Functions

### DIFF
--- a/pkg/ctl/functions/functions.go
+++ b/pkg/ctl/functions/functions.go
@@ -32,6 +32,7 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	)
 
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, createFunctionsCmd)
+	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, stopFunctionsCmd)
 
 	return resourceCmd
 }

--- a/pkg/ctl/functions/stop.go
+++ b/pkg/ctl/functions/stop.go
@@ -1,0 +1,145 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package functions
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	"github.com/streamnative/pulsarctl/pkg/pulsar"
+	"strconv"
+)
+
+func stopFunctionsCmd(vc *cmdutils.VerbCmd) {
+	desc := pulsar.LongDescription{}
+	desc.CommandUsedFor = "This command is used for stopping function instance."
+	desc.CommandPermission = "This command requires super-user permissions."
+
+	var examples []pulsar.Example
+
+	stop := pulsar.Example{
+		Desc: "Stops function instance",
+		Command: "pulsarctl functions stop \n" +
+			"\t--tenant public\n" +
+			"\t--namespace default\n" +
+			"\t--name <the name of Pulsar Function>",
+	}
+	examples = append(examples, stop)
+
+	stopWithInstanceID := pulsar.Example{
+		Desc: "Stops function instance with instance ID",
+		Command: "pulsarctl functions stop \n" +
+			"\t--tenant public\n" +
+			"\t--namespace default\n" +
+			"\t--name <the name of Pulsar Function>\n" +
+			"\t--instance-id 1",
+	}
+	examples = append(examples, stopWithInstanceID)
+
+	stopWithFQFN := pulsar.Example{
+		Desc: "Stops function instance with FQFN",
+		Command: "pulsarctl functions stop \n" +
+			"\t--fqfn tenant/namespace/name [eg: public/default/ExampleFunctions]",
+	}
+	examples = append(examples, stopWithFQFN)
+	desc.CommandExamples = examples
+
+	var out []pulsar.Output
+	successOut := pulsar.Output{
+		Desc: "normal output",
+		Out:  "Stopped successfully",
+	}
+
+	out = append(out, successOut)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"stop",
+		"",
+		desc.ToString(),
+		"stop",
+	)
+
+	functionData := &pulsar.FunctionData{}
+
+	// set the run function
+	vc.SetRunFunc(func() error {
+		return doStopFunctions(vc, functionData)
+	})
+
+	// register the params
+	vc.FlagSetGroup.InFlagSet("FunctionsConfig", func(flagSet *pflag.FlagSet) {
+		flagSet.StringVar(
+			&functionData.FQFN,
+			"fqfn",
+			"",
+			"The Fully Qualified Function Name (FQFN) for the function")
+
+		flagSet.StringVar(
+			&functionData.Tenant,
+			"tenant",
+			"",
+			"The tenant of a Pulsar Function")
+
+		flagSet.StringVar(
+			&functionData.Namespace,
+			"namespace",
+			"",
+			"The namespace of a Pulsar Function")
+
+		flagSet.StringVar(
+			&functionData.FuncName,
+			"name",
+			"",
+			"The name of a Pulsar Function")
+
+		flagSet.StringVar(
+			&functionData.InstanceID,
+			"instance-id",
+			"",
+			"The function instanceId (stop all instances if instance-id is not provided)")
+	})
+}
+
+func doStopFunctions(vc *cmdutils.VerbCmd, funcData *pulsar.FunctionData) error {
+	err := processBaseArguments(funcData)
+	if err != nil {
+		vc.Command.Help()
+		return err
+	}
+	admin := cmdutils.NewPulsarClientWithApiVersion(pulsar.V3)
+	if funcData.InstanceID != "" {
+		instanceID, err := strconv.Atoi(funcData.InstanceID)
+		if err != nil {
+			return err
+		}
+		err = admin.Functions().StopFunctionWithID(funcData.Tenant, funcData.Namespace, funcData.FuncName, instanceID)
+		if err != nil {
+			return err
+		}
+		vc.Command.Printf("Stopped %s successfully", funcData.FuncName)
+	} else {
+		err = admin.Functions().StopFunction(funcData.Tenant, funcData.Namespace, funcData.FuncName)
+		if err != nil {
+			return err
+		}
+
+		vc.Command.Printf("Stopped %s successfully", funcData.FuncName)
+	}
+
+	return nil
+}

--- a/pkg/ctl/functions/stop_test.go
+++ b/pkg/ctl/functions/stop_test.go
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package functions
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestStopFunctions(t *testing.T) {
+	jarName := "dummyExample.jar"
+	_, err := os.Create(jarName)
+	assert.Nil(t, err)
+
+	defer os.Remove(jarName)
+	args := []string{"create",
+		"--tenant", "public",
+		"--namespace", "default",
+		"--name", "test-functions-stop",
+		"--inputs", "test-input-topic",
+		"--output", "persistent://public/default/test-output-topic",
+		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
+		"--jar", jarName,
+	}
+
+	_, err = TestFunctionsCommands(createFunctionsCmd, args)
+	assert.Nil(t, err)
+
+	stopArgs := []string{"stop",
+		"--tenant", "public",
+		"--namespace", "default",
+		"--name", "test-functions-stop",
+	}
+
+	_, err = TestFunctionsCommands(stopFunctionsCmd, stopArgs)
+	assert.Nil(t, err)
+
+    argsFqfn := []string{"create",
+        "--tenant", "public",
+        "--namespace", "default",
+        "--name", "test-functions-stop-fqfn",
+        "--inputs", "test-input-topic",
+        "--output", "persistent://public/default/test-output-topic",
+        "--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
+        "--jar", jarName,
+    }
+
+    _, err = TestFunctionsCommands(createFunctionsCmd, argsFqfn)
+    assert.Nil(t, err)
+
+    stopArgsFqfn := []string{"stop",
+        "--fqfn", "public/default/test-functions-stop-fqfn",
+    }
+
+    _, err = TestFunctionsCommands(stopFunctionsCmd, stopArgsFqfn)
+    assert.Nil(t, err)
+}

--- a/pkg/pulsar/data.go
+++ b/pkg/pulsar/data.go
@@ -16,6 +16,7 @@ type FunctionData struct {
 	Tenant                    string  `json:"tenant"`
 	Namespace                 string  `json:"namespace"`
 	FuncName                  string  `json:"functionName"`
+	InstanceID				  string  `json:"instance_id"`
 	ClassName                 string  `json:"className"`
 	Jar                       string  `json:"jarFile"`
 	Py                        string  `json:"pyFile"`

--- a/pkg/pulsar/functions.go
+++ b/pkg/pulsar/functions.go
@@ -43,6 +43,12 @@ type Functions interface {
 	// @param pkgUrl
 	//      url from which pkg can be downloaded
 	CreateFuncWithUrl(data *FunctionConfig, pkgUrl string) error
+
+	// Stop all function instances
+	StopFunction(tenant, namespace, name string) error
+
+	// Stop function instance
+	StopFunctionWithID(tenant, namespace, name string, instanceID int) error
 }
 
 type functions struct {
@@ -173,4 +179,25 @@ func (f *functions) CreateFuncWithUrl(funcConf *FunctionConfig, pkgUrl string) e
 	}
 
 	return nil
+}
+
+func (f *functions) StopFunction(tenant, namespace, name string) error {
+    endpoint := f.client.endpoint(f.basePath, tenant, namespace, name)
+    err := f.client.post(endpoint+"/stop", "", nil)
+    if err != nil {
+        return err
+    }
+    return nil
+}
+
+func (f *functions) StopFunctionWithID(tenant, namespace, name string, instanceID int) error  {
+    id := fmt.Sprintf("%d", instanceID)
+    endpoint := f.client.endpoint(f.basePath, tenant, namespace, name, id)
+
+    err := f.client.post(endpoint+"/stop", "", nil)
+    if err != nil {
+        return err
+    }
+
+    return nil
 }


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

Add stop cmd for Pulsar Functions, the output as follows:

```
USED FOR:
    This command is used for stopping function instance.

REQUIRED PERMISSION:
    This command requires super-user permissions.

EXAMPLES:
    #Stops function instance
    pulsarctl functions stop
	--tenant public
	--namespace default
	--name <the name of Pulsar Function>

    #Stops function instance with instance ID
    pulsarctl functions stop
	--tenant public
	--namespace default
	--name <the name of Pulsar Function>
	--instance-id 1

    #Stops function instance with FQFN
    pulsarctl functions stop
	--fqfn tenant/namespace/name [eg: public/default/ExampleFunctions]

OUTPUT:
    #normal output
    Stopped successfully

Usage: pulsarctl functions stop [flags]

Aliases: stop, stop

FunctionsConfig flags:
      --fqfn string          The Fully Qualified Function Name (FQFN) for the function
      --tenant string        The tenant of a Pulsar Function
      --namespace string     The namespace of a Pulsar Function
      --name string          The name of a Pulsar Function
      --instance-id string   The function instanceId (stop all instances if instance-id is not provided)

```