### PR TITLE
Expose error to test

### DIFF
--- a/pkg/cmdutils/cmdutils.go
+++ b/pkg/cmdutils/cmdutils.go
@@ -2,6 +2,7 @@ package cmdutils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -29,11 +30,17 @@ func NewResourceCmd(use, short, long string, aliases ...string) *cobra.Command {
 	}
 }
 
+var CheckNameArgError = defaultNameArgsError
+
+var defaultNameArgsError = func(err error) {
+	os.Exit(1)
+}
+
 // GetNameArg tests to ensure there is only 1 name argument
 func GetNameArg(args []string) string {
 	if len(args) > 1 || len(args) == 0 {
 		logger.Critical("only one argument is allowed to be used as a name")
-		os.Exit(1)
+		CheckNameArgError(errors.New("only one argument is allowed to be used as a name"))
 	}
 	if len(args) == 1 {
 		return strings.TrimSpace(args[0])

--- a/pkg/cmdutils/verb.go
+++ b/pkg/cmdutils/verb.go
@@ -47,9 +47,15 @@ func (vc *VerbCmd) SetRunFuncWithNameArg(cmd func() error) {
 	}
 }
 
+var ExecErrorHandler  = defaultExecErrorHandler
+
+var defaultExecErrorHandler = func(err error) {
+	logger.Critical("%s\n", err.Error())
+	os.Exit(1)
+}
+
 func run(cmd func() error) {
 	if err := cmd(); err != nil {
-		logger.Critical("%s\n", err.Error())
-		os.Exit(1)
+		ExecErrorHandler(err)
 	}
 }

--- a/pkg/ctl/cluster/delete_test.go
+++ b/pkg/ctl/cluster/delete_test.go
@@ -8,21 +8,21 @@ import (
 
 func TestDeleteClusterCmd(t *testing.T) {
 	args := []string{"add", "test"}
-	_, err := TestClusterCommands(createClusterCmd, args)
+	_, _, _, err := TestClusterCommands(createClusterCmd, args)
 	assert.Nil(t, err)
 
 	args = []string{"list"}
-	out, err := TestClusterCommands(listClustersCmd, args)
+	out, _, _, err := TestClusterCommands(listClustersCmd, args)
 	assert.Nil(t, err)
 	clusters := out.String()
 	assert.True(t, strings.Contains(clusters, "test"))
 
 	args = []string{"delete", "test"}
-	_, err = TestClusterCommands(deleteClusterCmd, args)
+	_, _, _, err = TestClusterCommands(deleteClusterCmd, args)
 	assert.Nil(t, err)
 
 	args = []string{"list"}
-	out, err = TestClusterCommands(listClustersCmd, args)
+	out, _, _, err = TestClusterCommands(listClustersCmd, args)
 	assert.Nil(t, err)
 	clusters = out.String()
 	assert.False(t, strings.Contains(clusters, "test"))

--- a/pkg/ctl/cluster/get_peer_clusters_test.go
+++ b/pkg/ctl/cluster/get_peer_clusters_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestGetPeerClustersCmd(t *testing.T) {
 	args := []string{"add", "test_get_peer", "--peer-cluster", "standalone"}
-	_, err := TestClusterCommands(createClusterCmd, args)
+	_, _, _, err := TestClusterCommands(createClusterCmd, args)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	args = []string{"gpc", "test_get_peer"}
-	out, err := TestClusterCommands(getPeerClustersCmd, args)
+	out, _, _, err := TestClusterCommands(getPeerClustersCmd, args)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ctl/cluster/get_test.go
+++ b/pkg/ctl/cluster/get_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestGetClusterData(t *testing.T) {
 	args := []string{"get", "standalone"}
-	out, err := TestClusterCommands(getClusterDataCmd, args)
+	out, _, _, err := TestClusterCommands(getClusterDataCmd, args)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/ctl/cluster/test.go
+++ b/pkg/ctl/cluster/test.go
@@ -8,7 +8,18 @@ import (
 	"os"
 )
 
-func TestClusterCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (out *bytes.Buffer, err error)  {
+func TestClusterCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (out *bytes.Buffer, execErr, nameErr, err error)  {
+
+	var execError error
+	cmdutils.ExecErrorHandler = func(err error) {
+		execError = err
+	}
+
+	var nameError error
+	cmdutils.CheckNameArgError = func(err error) {
+		nameError = err
+	}
+
 	var rootCmd = &cobra.Command {
 		Use:	"pulsarctl [command]",
 		Short: 	"a CLI for Apache Pulsar",
@@ -34,7 +45,7 @@ func TestClusterCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (ou
 	rootCmd.AddCommand(resourceCmd)
 	err = rootCmd.Execute()
 
-	return buf, err
+	return buf, execError, nameError, err
 }
 
 var (

--- a/pkg/ctl/cluster/update_peer_clusters_test.go
+++ b/pkg/ctl/cluster/update_peer_clusters_test.go
@@ -9,19 +9,19 @@ import (
 
 func TestUpdatePeerClusters(t *testing.T) {
 	args := []string{"add", "test_peer_cluster"}
-	_, err := TestClusterCommands(createClusterCmd, args)
+	_, _, _, err := TestClusterCommands(createClusterCmd, args)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	args = []string{"update-peer-clusters", "-p", "test_peer_cluster", "standalone"}
-	_, err = TestClusterCommands(updatePeerClustersCmd, args)
+	_, _, _, err = TestClusterCommands(updatePeerClustersCmd, args)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	args = []string{"get", "standalone"}
-	out, err := TestClusterCommands(getClusterDataCmd, args)
+	out, _, _, err := TestClusterCommands(getClusterDataCmd, args)
 
 	var clusterData pulsar.ClusterData
 	err = json.Unmarshal(out.Bytes(), &clusterData)

--- a/pkg/ctl/cluster/update_test.go
+++ b/pkg/ctl/cluster/update_test.go
@@ -19,13 +19,13 @@ func TestUpdateCluster(t *testing.T) {
 		"standalone",
 	}
 
-	_, err := TestClusterCommands(updateClusterCmd, args)
+	_, _, _, err := TestClusterCommands(updateClusterCmd, args)
 	if err != nil {
 		t.Error(err)
 	}
 
 	args = []string{"get", "standalone"}
-	out, err := TestClusterCommands(getClusterDataCmd, args)
+	out, _, _, err := TestClusterCommands(getClusterDataCmd, args)
 
 	var data pulsar.ClusterData
 	err = json.Unmarshal(out.Bytes(), &data)


### PR DESCRIPTION
*Motivation*

We can't get the error info when running a command. When testing a command, we need to verify the error output.

*Modification*

Make a handler to handle errors. Create a test handler in `TestClusterCommand` for test other commands.

