### PR TITLE
Timer does not work

### DIFF
--- a/pkg/cmdutils/cmdutils.go
+++ b/pkg/cmdutils/cmdutils.go
@@ -113,10 +113,11 @@ func RunFuncWithTimeout(task func([]string, interface{}) bool, condition bool, t
 	defer ticker.Stop()
 
 	result := !condition
+	timer := time.After(timeout)
 
 	for condition != result {
 		select {
-		case <-time.After(timeout):
+		case <-timer:
 			return errors.New("task timeout")
 		case <-ticker.C:
 			result = task(args, obj)


### PR DESCRIPTION
---

*Motivation*

The `timer.After` will be reset when it enters the next loop. So the timeout will never happen.

*Modifications*

Move `time.After` out of the loop