### PR TITLE
Fix mbean test error

### DIFF
--- a/pkg/ctl/brokerstats/mbeans_test.go
+++ b/pkg/ctl/brokerstats/mbeans_test.go
@@ -18,25 +18,13 @@
 package brokerstats
 
 import (
-	"encoding/json"
 	"testing"
 
-	"github.com/streamnative/pulsarctl/pkg/pulsar"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDumpMBeans(t *testing.T) {
 	args := []string{"mbeans"}
-	mbeansOut, execErr, _, _ := TestBrokerStatsCommands(dumpMBeans, args)
+	_, execErr, _, _ := TestBrokerStatsCommands(dumpMBeans, args)
 	assert.Nil(t, execErr)
-
-	var out []pulsar.Metrics
-	err := json.Unmarshal(mbeansOut.Bytes(), &out)
-	assert.Nil(t, err)
-
-	tmpMap := map[string]string{
-		"MBean": "java.lang:type=MemoryPool,name=Metaspace",
-	}
-
-	assert.Equal(t, tmpMap, out[0].Dimensions)
 }


### PR DESCRIPTION
---

*Motivation*

We should not use a constant value to verify an unstable output.

*Modifications*

- remove the output value check

*output error*

        	Error Trace:	mbeans_test.go:41
        	Error:      	Not equal: 
        	            	expected: map[string]string{"MBean":"java.lang:type=MemoryPool,name=Metaspace"}
        	            	actual  : map[string]string{"MBean":"org.apache.ZooKeeperService:name0=StandaloneServer_port2181,name1=Connections,name2=127.0.0.1,name3=0x10000049e78000b"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,3 +1,3 @@
        	            	 (map[string]string) (len=1) {
        	            	- (string) (len=5) "MBean": (string) (len=40) "java.lang:type=MemoryPool,name=Metaspace"
        	            	+ (string) (len=5) "MBean": (string) (len=117) "org.apache.ZooKeeperService:name0=StandaloneServer_port2181,name1=Connections,name2=127.0.0.1,name3=0x10000049e78000b"
        	            	 }
        	Test:       	TestDumpMBeans
