### PR TITLE
Fix the moniotring_metrics_test

### DIFF
--- a/pkg/ctl/brokerstats/monitoring_metrics_test.go
+++ b/pkg/ctl/brokerstats/monitoring_metrics_test.go
@@ -18,10 +18,9 @@
 package brokerstats
 
 import (
-	"encoding/json"
+	"strings"
 	"testing"
 
-	"github.com/streamnative/pulsarctl/pkg/pulsar"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,15 +28,5 @@ func TestDumpMonitoringMetrics(t *testing.T) {
 	args := []string{"monitoring-metrics"}
 	metricsOut, execErr, _, _ := TestBrokerStatsCommands(dumpMonitoringMetrics, args)
 	assert.Nil(t, execErr)
-
-	var out []pulsar.Metrics
-	err := json.Unmarshal(metricsOut.Bytes(), &out)
-	assert.Nil(t, err)
-
-	var value string
-	for i := 0; i < len(out); i++ {
-		value = out[i].Dimensions["cluster"]
-	}
-
-	assert.Equal(t, "standalone", value)
+	assert.True(t, strings.Contains(metricsOut.String(), "standalone"))
 }


### PR DESCRIPTION
---

*Motivation*

```
var value string	
	for i := 0; i < len(out); i++ {	
		value = out[i].Dimensions["cluster"]	
	}
```
The test is always failed with the `assert.Equal(t, "standalone", value)`. The value can be reset when the next value of the out. And the out is not always has the `Dimensions["cluster"]`.

*Modifications*

- Use `contains` verify to replace `Equal` verify

---
The output contains multiple dimensions, the `cluster: standalone` is not appear every time.

```
{
    "metrics": {
      "brk_ml_cache_evictions": 0,
      "brk_ml_cache_hits_rate": 0,
      "brk_ml_cache_hits_throughput": 0,
      "brk_ml_cache_misses_rate": 0,
      "brk_ml_cache_misses_throughput": 0,
      "brk_ml_cache_pool_active_allocations": 0,
      "brk_ml_cache_pool_active_allocations_huge": 0,
      "brk_ml_cache_pool_active_allocations_normal": 0,
      "brk_ml_cache_pool_active_allocations_small": 0,
      "brk_ml_cache_pool_active_allocations_tiny": 0,
      "brk_ml_cache_pool_allocated": 0,
      "brk_ml_cache_pool_used": 0,
      "brk_ml_cache_used_size": 0,
      "brk_ml_count": 0
    },
    "dimensions": {}
  },
  {
    "metrics": {
      "brk_zk_write_rate_s": 0,
      "brk_zk_write_time_75percentile_ms": "NaN",
      "brk_zk_write_time_95percentile_ms": "NaN",
      "brk_zk_write_time_99_99_percentile_ms": "NaN",
      "brk_zk_write_time_99_9_percentile_ms": "NaN",
      "brk_zk_write_time_99_percentile_ms": "NaN",
      "brk_zk_write_time_mean_ms": "NaN",
      "brk_zk_write_time_median_ms": "NaN"
    },
    "dimensions": {
      "broker": "1f720f22f6da",
      "cluster": "standalone",
      "metric": "zk_write_latency"
    }
  },
  {
    "metrics": {
      "brk_topic_load_rate_s": 0,
      "brk_topic_load_time_75percentile_ms": "NaN",
      "brk_topic_load_time_95percentile_ms": "NaN",
      "brk_topic_load_time_99_99_percentile_ms": "NaN",
      "brk_topic_load_time_99_9_percentile_ms": "NaN",
      "brk_topic_load_time_99_percentile_ms": "NaN",
      "brk_topic_load_time_mean_ms": "NaN",
      "brk_topic_load_time_median_ms": "NaN"
    },
    "dimensions": {
      "broker": "1f720f22f6da",
      "cluster": "standalone",
      "metric": "topic_load_times"
    }
  },
  {
    "metrics": {
      "brk_zk_read_rate_s": 0,
      "brk_zk_read_time_75percentile_ms": "NaN",
      "brk_zk_read_time_95percentile_ms": "NaN",
      "brk_zk_read_time_99_99_percentile_ms": "NaN",
      "brk_zk_read_time_99_9_percentile_ms": "NaN",
      "brk_zk_read_time_99_percentile_ms": "NaN",
      "brk_zk_read_time_mean_ms": "NaN",
      "brk_zk_read_time_median_ms": "NaN"
    },
    "dimensions": {
      "broker": "1f720f22f6da",
      "cluster": "standalone",
      "metric": "zk_read_latency"
    }
  },
  {
    "metrics": {
      "brk_default_pool_allocated": 33554432,
      "brk_default_pool_used": 180224,
      "jvm_direct_memory_used": 2181038087,
      "jvm_gc_old_count": 0,
      "jvm_gc_old_pause": 0,
      "jvm_gc_young_count": 0,
      "jvm_gc_young_pause": 0,
      "jvm_heap_used": 655680880,
      "jvm_max_direct_memory": 4294967296,
      "jvm_max_memory": 2147483648,
      "jvm_thread_cnt": 172,
      "jvm_total_memory": 2147483648
    },
    "dimensions": {
      "metric": "jvm_metrics"
    }
  }
```