### PR TITLE
Remove `sudo` from the build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ MINOR_VERSION=1
 # Build pulsarctl docs
 
 cleancli:
-	sudo rm -f main
-	sudo rm -rf $(shell pwd)/site/gen-pulsarctldocs/generators/includes
-	sudo rm -rf $(shell pwd)/site/gen-pulsarctldocs/generators/build
-	sudo rm -rf $(shell pwd)/site/gen-pulsarctldocs/generators/manifest.json
+	rm -f main
+	rm -rf $(shell pwd)/site/gen-pulsarctldocs/generators/includes
+	rm -rf $(shell pwd)/site/gen-pulsarctldocs/generators/build
+	rm -rf $(shell pwd)/site/gen-pulsarctldocs/generators/manifest.json
 
 cli: cleancli
 	go run site/gen-pulsarctldocs/main.go --pulsar-version v1_$(MINOR_VERSION)


### PR DESCRIPTION
*Motivation*

`sudo` is not needed for that build script