### PR TITLE
[BK-SUPPORT-PART-2] Support bookkeeper ledger commands

### DIFF
--- a/pkg/bkctl/bk.go
+++ b/pkg/bkctl/bk.go
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package bkctl
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/streamnative/pulsarctl/pkg/bkctl/ledger"
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+)
+
+func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
+	resourceCmd := cmdutils.NewResourceCmd(
+		"bookkeeper",
+		"Operations about bookKeeper",
+		"",
+		"bk",
+	)
+
+	resourceCmd.AddCommand(ledger.Command(flagGrouping))
+
+	return resourceCmd
+}

--- a/pkg/bkctl/ledger/delete.go
+++ b/pkg/bkctl/ledger/delete.go
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ledger
+
+import (
+	"strconv"
+
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+
+	"github.com/pkg/errors"
+)
+
+func deleteCmd(vc *cmdutils.VerbCmd) {
+	var desc cmdutils.LongDescription
+	desc.CommandUsedFor = "This command is used for deleting a ledger."
+	desc.CommandPermission = "none"
+
+	var examples []cmdutils.Example
+	deleteLedger := cmdutils.Example{
+		Desc:    "Delete the specified ledger",
+		Command: "pulsarctl bookkeeper ledger delete --ledger-id (ledger-id)",
+	}
+	examples = append(examples, deleteLedger)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Successfully delete the ledger (ledger-id)",
+	}
+	out = append(out, successOut, argError)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"delete",
+		"Delete a ledger",
+		desc.ToString(),
+		desc.ExampleToString())
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doDeleteCmd(vc)
+	}, "the ledger id is not specified or the ledger id is specified more than one")
+}
+
+func doDeleteCmd(vc *cmdutils.VerbCmd) error {
+	id, err := strconv.ParseInt(vc.NameArg, 10, 64)
+	if err != nil || id < 0 {
+		return errors.Errorf("invalid ledger id %s", vc.NameArg)
+	}
+
+	admin := cmdutils.NewBookieClient()
+	err = admin.Ledger().Delete(id)
+	if err == nil {
+		vc.Command.Printf("Successfully delete the ledger %d\n", id)
+	}
+
+	return err
+}

--- a/pkg/bkctl/ledger/delete_test.go
+++ b/pkg/bkctl/ledger/delete_test.go
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteArgError(t *testing.T) {
+	args := []string{"delete"}
+	_, _, nameErr, _ := testLedgerCommands(deleteCmd, args)
+	assert.NotNil(t, nameErr)
+	assert.Equal(t, "the ledger id is not specified or the ledger id is specified more than one",
+		nameErr.Error())
+
+	args = []string{"delete", "a"}
+	_, execErr, _, _ := testLedgerCommands(deleteCmd, args)
+	assert.NotNil(t, execErr)
+	assert.Equal(t, "invalid ledger id a", execErr.Error())
+
+	args = []string{"delete", "--", "-1"}
+	_, execErr, _, _ = testLedgerCommands(deleteCmd, args)
+	assert.NotNil(t, execErr)
+	assert.Equal(t, "invalid ledger id -1", execErr.Error())
+}

--- a/pkg/bkctl/ledger/errors.go
+++ b/pkg/bkctl/ledger/errors.go
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ledger
+
+import "github.com/streamnative/pulsarctl/pkg/cmdutils"
+
+var argError = cmdutils.Output{
+	Desc: "the ledger id is not specified or the ledger id is specified more than one",
+	Out:  "[✖]  the ledger id is not specified or the ledger id is specified more than one",
+}

--- a/pkg/bkctl/ledger/get.go
+++ b/pkg/bkctl/ledger/get.go
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ledger
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/streamnative/pulsarctl/pkg/bookkeeper/bkdata"
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+
+	"github.com/pkg/errors"
+)
+
+func getCmd(vc *cmdutils.VerbCmd) {
+	var desc cmdutils.LongDescription
+	desc.CommandUsedFor = "This command is used for getting the metadata of a ledger."
+	desc.CommandPermission = "none"
+
+	var examples []cmdutils.Example
+	get := cmdutils.Example{
+		Desc:    "Get the metadata of the specified ledger",
+		Command: "pulsarctl bookkeeper ledger get (ledger-i)",
+	}
+	examples = append(examples, get)
+	desc.CommandExamples = examples
+
+	metadata := bkdata.LedgerMetadata{
+		MetadataFormatVersion: 1,
+		Ensemble:              1,
+		WriteQuorum:           1,
+		AckQuorum:             1,
+		Length:                1,
+		LastEntryID:           1,
+		Ctime:                 1,
+		CToken:                0,
+		State:                 "CLOSED",
+		DigestType:            "MAC",
+		Ensembles: map[int64][]bkdata.BookieSocketAddress{
+			1: {
+				bkdata.BookieSocketAddress{
+					HostName: "www.examples.com",
+					Port:     8080,
+				},
+			},
+		},
+		CurrentEnsemble: []bkdata.BookieSocketAddress{
+			{
+				HostName: "www.example.com",
+				Port:     8080,
+			},
+		},
+		Password:       make([]byte, 0),
+		CustomMetadata: map[string][]byte{},
+	}
+	meta, _ := json.MarshalIndent(metadata, "", "    ")
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  string(meta),
+	}
+	out = append(out, successOut, argError)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"get",
+		"Get the metadata of a ledger",
+		desc.ToString(),
+		desc.ExampleToString())
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doGet(vc)
+	}, "the ledger id is not specified or the ledger id is specified more than one")
+}
+
+func doGet(vc *cmdutils.VerbCmd) error {
+	id, err := strconv.ParseInt(vc.NameArg, 10, 64)
+	if err != nil || id < 0 {
+		return errors.Errorf("invalid ledger id %s", vc.NameArg)
+	}
+
+	admin := cmdutils.NewBookieClient()
+	metadata, err := admin.Ledger().Get(id)
+	if err == nil {
+		cmdutils.PrintJSON(vc.Command.OutOrStdout(), metadata)
+	}
+
+	return err
+}

--- a/pkg/bkctl/ledger/get_test.go
+++ b/pkg/bkctl/ledger/get_test.go
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetArgError(t *testing.T) {
+	args := []string{"get"}
+	_, _, nameErr, _ := testLedgerCommands(getCmd, args)
+	assert.NotNil(t, nameErr)
+	assert.Equal(t, "the ledger id is not specified or the ledger id is specified more than one",
+		nameErr.Error())
+
+	args = []string{"get", "a"}
+	_, execErr, _, _ := testLedgerCommands(getCmd, args)
+	assert.NotNil(t, execErr)
+	assert.Equal(t, "invalid ledger id a", execErr.Error())
+
+	args = []string{"get", "--", "-1"}
+	_, execErr, _, _ = testLedgerCommands(getCmd, args)
+	assert.NotNil(t, execErr)
+	assert.Equal(t, "invalid ledger id -1", execErr.Error())
+}

--- a/pkg/bkctl/ledger/ledger.go
+++ b/pkg/bkctl/ledger/ledger.go
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ledger
+
+import (
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+
+	"github.com/spf13/cobra"
+)
+
+func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
+	resourceCmd := cmdutils.NewResourceCmd(
+		"ledger",
+		"Operations about ledger",
+		"",
+		"")
+
+	commands := []func(*cmdutils.VerbCmd){
+		deleteCmd,
+		getCmd,
+		listCmd,
+		readCmd,
+	}
+
+	cmdutils.AddVerbCmds(flagGrouping, resourceCmd, commands...)
+
+	return resourceCmd
+}

--- a/pkg/bkctl/ledger/list.go
+++ b/pkg/bkctl/ledger/list.go
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ledger
+
+import (
+	"sort"
+
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+
+	"github.com/spf13/pflag"
+)
+
+func listCmd(vc *cmdutils.VerbCmd) {
+	var desc cmdutils.LongDescription
+	desc.CommandUsedFor = "This command is used for listing all the ledgers."
+	desc.CommandPermission = "none"
+
+	var examples []cmdutils.Example
+	list := cmdutils.Example{
+		Desc:    "List all the ledgers",
+		Command: "pulsarctl bookkeeper ledger list",
+	}
+
+	showMeta := cmdutils.Example{
+		Desc:    "List all the ledgers and the metadata of the ledger",
+		Command: "pulsarctl bookkeeper ledger list --show-metadata",
+	}
+	examples = append(examples, list, showMeta)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "[1,2,3,4]",
+	}
+	out = append(out, successOut)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"list",
+		"list all the ledgers",
+		desc.ToString(),
+		desc.ExampleToString())
+
+	var show bool
+
+	vc.SetRunFunc(func() error {
+		return doListCmd(vc, show)
+	})
+
+	vc.FlagSetGroup.InFlagSet("List Ledgers", func(set *pflag.FlagSet) {
+		set.BoolVarP(&show, "show-metadata", "p", false,
+			"Show the metadata of the ledgers")
+	})
+}
+
+func doListCmd(vc *cmdutils.VerbCmd, showMeta bool) error {
+	admin := cmdutils.NewBookieClient()
+	ledgers, err := admin.Ledger().List(showMeta)
+	if err == nil {
+		if !showMeta {
+			ledgerList := make([]int64, 0)
+			for k := range ledgers {
+				ledgerList = append(ledgerList, k)
+			}
+			sort.Slice(ledgerList, func(i, j int) bool {
+				return ledgerList[i] < ledgerList[j]
+			})
+			vc.Command.Println(ledgerList)
+		} else {
+			cmdutils.PrintJSON(vc.Command.OutOrStdout(), ledgers)
+		}
+	}
+	return err
+}

--- a/pkg/bkctl/ledger/read.go
+++ b/pkg/bkctl/ledger/read.go
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ledger
+
+import (
+	"strconv"
+
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+)
+
+func readCmd(vc *cmdutils.VerbCmd) {
+	var desc cmdutils.LongDescription
+	desc.CommandUsedFor = "This command is used for reading a range of entries of a ledger."
+	desc.CommandPermission = "none"
+
+	var examples []cmdutils.Example
+	r := cmdutils.Example{
+		Desc:    "Read a range of entries of the specified ledger",
+		Command: "pulsar bookkeeper ledger read (ledger-id)",
+	}
+
+	rs := cmdutils.Example{
+		Desc:    "Read the entries of the specified ledger started from the given entry id",
+		Command: "pulsar bookkeeper ledger --start (entry-id) (ledger-id)",
+	}
+
+	rse := cmdutils.Example{
+		Desc:    "Read the specified range of entries of the specified ledger",
+		Command: "pulsar bookkeeper ledger --start (entry-id) --end (entry-id) (ledger-id)",
+	}
+
+	examples = append(examples, r, rs, rse)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out: `{
+	"ledger-id", "message"
+}`,
+	}
+	out = append(out, successOut, argError)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"read",
+		"Read a range of entries of a ledger",
+		desc.ToString(),
+		desc.ExampleToString())
+
+	var start int64
+	var end int64
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doRead(vc, start, end)
+	}, "the ledger id is not specified or the ledger id is specified more than one")
+
+	vc.FlagSetGroup.InFlagSet("Read Ledger", func(set *pflag.FlagSet) {
+		set.Int64VarP(&start, "start", "b", -1,
+			"")
+		set.Int64VarP(&end, "end", "e", -1, "")
+	})
+
+}
+
+func doRead(vc *cmdutils.VerbCmd, start, end int64) error {
+	id, err := strconv.ParseInt(vc.NameArg, 10, 64)
+	if err != nil || id < 0 {
+		return errors.Errorf("invalid ledger id %s", vc.NameArg)
+	}
+
+	if start != -1 && start < 0 {
+		return errors.Errorf("invalid start ledger id %d", start)
+	}
+
+	if end != -1 && end < 0 {
+		return errors.Errorf("invalid end ledger id %d", end)
+	}
+
+	admin := cmdutils.NewBookieClient()
+	info, err := admin.Ledger().Read(id, start, end)
+	if err == nil {
+		cmdutils.PrintJSON(vc.Command.OutOrStdout(), info)
+	}
+
+	return err
+}

--- a/pkg/bkctl/ledger/read_test.go
+++ b/pkg/bkctl/ledger/read_test.go
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadArgError(t *testing.T) {
+	args := []string{"read"}
+	_, _, nameErr, _ := testLedgerCommands(readCmd, args)
+	assert.NotNil(t, nameErr)
+	assert.Equal(t, "the ledger id is not specified or the ledger id is specified more than one",
+		nameErr.Error())
+
+	args = []string{"read", "a"}
+	_, execErr, _, _ := testLedgerCommands(readCmd, args)
+	assert.NotNil(t, execErr)
+	assert.Equal(t, "invalid ledger id a", execErr.Error())
+
+	args = []string{"read", "--", "-1"}
+	_, execErr, _, _ = testLedgerCommands(readCmd, args)
+	assert.NotNil(t, execErr)
+	assert.Equal(t, "invalid ledger id -1", execErr.Error())
+
+	args = []string{"read", "--start", "-2", "1"}
+	_, execErr, _, _ = testLedgerCommands(readCmd, args)
+	assert.NotNil(t, execErr)
+	assert.Equal(t, "invalid start ledger id -2", execErr.Error())
+
+	args = []string{"read", "--end", "-2", "1"}
+	_, execErr, _, _ = testLedgerCommands(readCmd, args)
+	assert.NotNil(t, execErr)
+	assert.Equal(t, "invalid end ledger id -2", execErr.Error())
+}

--- a/pkg/bkctl/ledger/test_help.go
+++ b/pkg/bkctl/ledger/test_help.go
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ledger
+
+import (
+	"bytes"
+
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+
+	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
+)
+
+func testLedgerCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (out *bytes.Buffer,
+	execErr, nameErr, err error) {
+
+	var execError error
+	cmdutils.ExecErrorHandler = func(err error) {
+		execError = err
+	}
+
+	var nameError error
+	cmdutils.CheckNameArgError = func(err error) {
+		nameError = err
+	}
+
+	var rootCmd = &cobra.Command{
+		Use:   "pulsarctl [command]",
+		Short: "a CLI for Apache Pulsar",
+		Run: func(cmd *cobra.Command, _ []string) {
+			if err := cmd.Help(); err != nil {
+				logger.Debug("ignoring error %q", err.Error())
+			}
+		},
+	}
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs(append([]string{"ledger"}, args...))
+
+	resourceCmd := cmdutils.NewResourceCmd(
+		"ledger",
+		"Operations about bookie(s)",
+		"",
+		"")
+	flagGrouping := cmdutils.NewGrouping()
+	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
+	rootCmd.AddCommand(resourceCmd)
+	err = rootCmd.Execute()
+
+	return buf, execError, nameError, err
+}

--- a/pkg/bookkeeper/admin.go
+++ b/pkg/bookkeeper/admin.go
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package bookkeeper
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+
+	"github.com/streamnative/pulsarctl/pkg/bookkeeper/bkdata"
+	"github.com/streamnative/pulsarctl/pkg/cli"
+)
+
+type Client interface {
+	// Ledger related commands
+	Ledger() Ledger
+}
+
+type bookieClient struct {
+	Client     *cli.Client
+	APIVersion bkdata.APIVersion
+}
+
+func New(config *Config) (Client, error) {
+	if len(config.WebServiceURL) == 0 {
+		config.WebServiceURL = DefaultWebServiceURL
+	}
+
+	bkClient := &bookieClient{
+		APIVersion: config.APIVersion,
+		Client: &cli.Client{
+			ServiceURL:  config.WebServiceURL,
+			VersionInfo: ReleaseVersion,
+			HTTPClient: &http.Client{
+				Timeout: config.HTTPTimeout,
+			},
+		},
+	}
+
+	return bkClient, nil
+}
+
+func (b *bookieClient) endpoint(componentPath string, parts ...string) string {
+	return path.Join(makeHTTPPath(b.APIVersion.String(), componentPath), path.Join(parts...))
+}
+
+func makeHTTPPath(apiVersion string, componentPath string) string {
+	return fmt.Sprintf("/api/%s%s", apiVersion, componentPath)
+}

--- a/pkg/bookkeeper/admin_config.go
+++ b/pkg/bookkeeper/admin_config.go
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package bookkeeper
+
+import (
+	"time"
+
+	"github.com/streamnative/pulsarctl/pkg/bookkeeper/bkdata"
+)
+
+const (
+	DefaultWebServiceURL       = "http://localhost:8080"
+	DefaultHTTPTimeOutDuration = 5 * time.Minute
+)
+
+var ReleaseVersion = "None"
+
+// Config is used to configure the bookKeeper admin client
+type Config struct {
+	WebServiceURL string
+	HTTPTimeout   time.Duration
+	APIVersion    bkdata.APIVersion
+}
+
+// DefaultConfig for a bookKeeper admin client
+func DefaultConfig() *Config {
+	return &Config{
+		WebServiceURL: DefaultWebServiceURL,
+		HTTPTimeout:   DefaultHTTPTimeOutDuration,
+	}
+}

--- a/pkg/bookkeeper/bkdata/api_version.go
+++ b/pkg/bookkeeper/bkdata/api_version.go
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package bkdata
+
+type APIVersion int
+
+const (
+	V1 APIVersion = iota
+)
+
+const DefaultAPIVersion = "v1"
+
+func (v APIVersion) String() string {
+	if v == V1 {
+		return "v1"
+	}
+
+	return DefaultAPIVersion
+}

--- a/pkg/bookkeeper/bkdata/ledger_metadata.go
+++ b/pkg/bookkeeper/bkdata/ledger_metadata.go
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package bkdata
+
+type BookieSocketAddress struct {
+	Port     int    `json:"port"`
+	HostName string `json:"hostname"`
+}
+
+type LedgerMetadata struct {
+	StoreCtime            bool                            `json:"storeCtime"`
+	HasPassword           bool                            `json:"hasPassword"`
+	MetadataFormatVersion int                             `json:"metadataFormatVersion"`
+	Ensemble              int                             `json:"ensembleSize"`
+	WriteQuorum           int                             `json:"writeQuorumSize"`
+	AckQuorum             int                             `json:"ackQuorumSize"`
+	Length                int64                           `json:"length"`
+	LastEntryID           int64                           `json:"lastEntryId"`
+	Ctime                 int64                           `json:"ctime"`
+	CToken                int64                           `json:"cToken"`
+	State                 string                          `json:"state"`
+	DigestType            string                          `json:"digestType"`
+	Ensembles             map[int64][]BookieSocketAddress `json:"allEnsembles"`
+	CurrentEnsemble       []BookieSocketAddress           `json:"currentEnsemble"`
+	Password              []byte                          `json:"password"`
+	CustomMetadata        map[string][]byte               `json:"customMetadata"`
+}

--- a/pkg/bookkeeper/ledger.go
+++ b/pkg/bookkeeper/ledger.go
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package bookkeeper
+
+import (
+	"strconv"
+
+	"github.com/streamnative/pulsarctl/pkg/bookkeeper/bkdata"
+	"github.com/streamnative/pulsarctl/pkg/cli"
+)
+
+type Ledger interface {
+	// Delete the specified ledger
+	Delete(int64) error
+
+	// List all the ledgers and get the metadata
+	List(bool) (map[int64]string, error)
+
+	// Get the metadata of a ledger
+	Get(int64) (map[int64]bkdata.LedgerMetadata, error)
+
+	// Read a range of entries from a ledger
+	Read(int64, int64, int64) (map[string]string, error)
+}
+
+type ledger struct {
+	client   *bookieClient
+	request  *cli.Client
+	basePath string
+	params   map[string]string
+}
+
+func (c *bookieClient) Ledger() Ledger {
+	return &ledger{
+		client:   c,
+		request:  c.Client,
+		basePath: "/ledger",
+		params:   make(map[string]string),
+	}
+}
+
+func (c *ledger) Delete(ledgerID int64) error {
+	endpoint := c.client.endpoint(c.basePath, "/delete")
+	c.params["ledger_id"] = strconv.FormatInt(ledgerID, 10)
+	return c.request.DeleteWithQueryParams(endpoint, c.params)
+}
+
+func (c *ledger) List(showMeta bool) (map[int64]string, error) {
+	endpoint := c.client.endpoint(c.basePath, "list")
+	c.params["print_metadata"] = strconv.FormatBool(showMeta)
+	var metadata map[int64]string
+	_, err := c.request.GetWithQueryParams(endpoint, &metadata, c.params, true)
+	return metadata, err
+}
+
+func (c *ledger) Get(ledgerID int64) (map[int64]bkdata.LedgerMetadata, error) {
+	endpoint := c.client.endpoint(c.basePath, "metadata")
+	c.params["ledger_id"] = strconv.FormatInt(ledgerID, 10)
+	var metadata map[int64]bkdata.LedgerMetadata
+	_, err := c.request.GetWithQueryParams(endpoint, &metadata, c.params, true)
+	return metadata, err
+}
+
+func (c *ledger) Read(ledgerID int64, start int64, end int64) (map[string]string, error) {
+	endpoint := c.client.endpoint(c.basePath, "read")
+	c.params["ledger_id"] = strconv.FormatInt(ledgerID, 10)
+	if start >= 0 {
+		c.params["start_entry_id"] = strconv.FormatInt(start, 10)
+	}
+	if end >= 0 {
+		c.params["end_entry_id"] = strconv.FormatInt(end, 10)
+	}
+	info := make(map[string]string)
+	_, err := c.request.GetWithQueryParams(endpoint, &info, c.params, true)
+	return info, err
+}

--- a/pkg/cmdutils/cmdutils.go
+++ b/pkg/cmdutils/cmdutils.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/streamnative/pulsarctl/pkg/bookkeeper"
 	"github.com/streamnative/pulsarctl/pkg/pulsar"
 	"github.com/streamnative/pulsarctl/pkg/pulsar/common"
 
@@ -87,6 +88,10 @@ func NewPulsarClient() pulsar.Client {
 
 func NewPulsarClientWithAPIVersion(version common.APIVersion) pulsar.Client {
 	return PulsarCtlConfig.Client(version)
+}
+
+func NewBookieClient() bookkeeper.Client {
+	return PulsarCtlConfig.BookieClient()
 }
 
 func PrintJSON(w io.Writer, obj interface{}) {

--- a/pkg/pulsarctl.go
+++ b/pkg/pulsarctl.go
@@ -18,6 +18,7 @@
 package pkg
 
 import (
+	"github.com/streamnative/pulsarctl/pkg/bkctl"
 	"github.com/streamnative/pulsarctl/pkg/cmdutils"
 	"github.com/streamnative/pulsarctl/pkg/ctl/brokers"
 	"github.com/streamnative/pulsarctl/pkg/ctl/brokerstats"
@@ -98,6 +99,9 @@ func NewPulsarctlCmd() *cobra.Command {
 	rootCmd.AddCommand(brokerstats.Command(flagGrouping))
 	rootCmd.AddCommand(resourcequotas.Command(flagGrouping))
 	rootCmd.AddCommand(functionsworker.Command(flagGrouping))
+
+	// bookie commands group
+	rootCmd.AddCommand(bkctl.Command(flagGrouping))
 
 	return rootCmd
 }


### PR DESCRIPTION
---

Master Issue: #127

*Motivation*

Support bookkeeper ledger commands in Pulsarctl

*Modifications*

Add bookkeeper ledger commands


*Output*

```
➜  pulsarctl-yong git:(ledger_cmd) ./pulsarctl bookkeeper  ledger
Operations about ledger

Usage: pulsarctl bookkeeper ledger [flags]

Commands:
  delete      Delete a ledger
  get         Get the metadata of a ledger
  list        list all the ledgers
  read        Read a range of entries of a ledger

Aliases: ledger,

Common flags:
  -s, --admin-service-url string    The admin web service url that pulsarctl connects to. (default "http://localhost:8080")
      --auth-params string          Authentication parameters are used to configure the public and private key files required by tls
                                     For example: "tlsCertFile:val1,tlsKeyFile:val2"
      --bookie-service-url string   The bookie web service url that pulsarctl connects to. (default "http://localhost:8080")
  -C, --color string                toggle colorized logs (true,false,fabulous) (default "true")
  -h, --help                        help for this command
      --tls-allow-insecure          Allow TLS insecure connection
      --tls-trust-cert-pat string   Allow TLS trust cert file path
      --token string                Using the token to authentication
      --token-file string           Using the token file to authentication
  -v, --verbose int                 set log level, use 0 to silence, 4 for debugging (default 3)

Use 'pulsarctl bookkeeper ledger [command] --help' for more information about a command.
```