### PR TITLE
Remove the BookKeeper commands

### DIFF
--- a/pkg/pulsarctl.go
+++ b/pkg/pulsarctl.go
@@ -18,7 +18,6 @@
 package pkg
 
 import (
-	"github.com/streamnative/pulsarctl/pkg/bkctl"
 	"github.com/streamnative/pulsarctl/pkg/cmdutils"
 	"github.com/streamnative/pulsarctl/pkg/ctl/brokers"
 	"github.com/streamnative/pulsarctl/pkg/ctl/brokerstats"
@@ -99,9 +98,6 @@ func NewPulsarctlCmd() *cobra.Command {
 	rootCmd.AddCommand(brokerstats.Command(flagGrouping))
 	rootCmd.AddCommand(resourcequotas.Command(flagGrouping))
 	rootCmd.AddCommand(functionsworker.Command(flagGrouping))
-
-	// bookie commands group
-	rootCmd.AddCommand(bkctl.Command(flagGrouping))
 
 	return rootCmd
 }


### PR DESCRIPTION
---

*Motivation*

The doc util can only generate subcommands like namespace, topics. The BookKeeper command is a new resource command of Pulsarctl. The doc cannot recognize the resource commands and will fail when to generate the website. So we remove the BookKeeper resource command from Pulsarctl rootCmd. For releasing the 0.2.0 I will fix the problem at the next pull request. Also, I add a new CI to precheck if the doc that can be generated successfully.
