### PR TITLE
Fixes unexpected error when request using pulsar 2.4.2 proxy

### DIFF
--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -63,15 +63,11 @@ func (c *Client) doRequest(r *request) (*http.Response, error) {
 		return nil, err
 	}
 
-	switch r.method {
-	case http.MethodPut:
-		fallthrough
-	case http.MethodPost:
-		if r.contentType != "" {
-			req.Header.Set("Content-Type", r.contentType)
-		} else {
-			req.Header.Set("Content-Type", "application/json")
-		}
+	switch {
+	case req.Body != nil:
+		req.Header.Set("Content-Type", "application/json")
+	case r.contentType != "":
+		req.Header.Set("Content-Type", r.contentType)
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", c.useragent())

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -63,12 +63,12 @@ func (c *Client) doRequest(r *request) (*http.Response, error) {
 		return nil, err
 	}
 
-	switch {
-	case req.Body != nil:
-		req.Header.Set("Content-Type", "application/json")
-	case r.contentType != "":
+	if r.contentType != "" {
 		req.Header.Set("Content-Type", r.contentType)
+	} else if req.Body != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
+
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", c.useragent())
 

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -63,11 +63,15 @@ func (c *Client) doRequest(r *request) (*http.Response, error) {
 		return nil, err
 	}
 
-	if r.contentType != "" {
-		req.Header.Set("Content-Type", r.contentType)
-	} else {
-		// add default headers
-		req.Header.Set("Content-Type", "application/json")
+	switch r.method {
+	case http.MethodPut:
+		fallthrough
+	case http.MethodPost:
+		if r.contentType != "" {
+			req.Header.Set("Content-Type", r.contentType)
+		} else {
+			req.Header.Set("Content-Type", "application/json")
+		}
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", c.useragent())


### PR DESCRIPTION
---

*Motivation*

When sending a GET or DELETE request to the Pulsar proxy, the server
always threw an IllegalArgumentException. By my test that's because
we are setting the Content-Type for a request without the request body.
We remove the Content-Type if the request is GET or DELETE.

*Modifications*

- Remove the header Content-Type for the GET and DELETE requests