### PR TITLE
Add zsh and bash auto completion docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ export GO111MODULE=on
 go build -o pulsarctl main.go
 ```
 
-## Optional pulsarctl configurations
+## Enable Auto-Completion
 
 If you want to enable autocompletion in shell, see [enable_completion](docs/en/enable_completion.md).
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ export GO111MODULE=on
 go build -o pulsarctl main.go
 ```
 
+## Optional pulsarctl configurations
+
+If you want to enable autocompletion in shell, see [enable_completion](docs/en/enable_completion.md).
+
 ## Project Status
 
 The following is an incomplete list of features that are not yet implemented:

--- a/docs/en/enable_completion.md
+++ b/docs/en/enable_completion.md
@@ -17,6 +17,7 @@ Include the directory in your $fpath, for example by adding in ~/.zshrc:
 
 ```bash
 fpath=($fpath ~/.zsh/completion)
+source ~/.zshrc
 ```
 
 You may have to force rebuild zcompdump:
@@ -27,4 +28,48 @@ rm -f ~/.zcompdump; compinit
 
 ### Bash
 
+#### Introduction
 
+The pulsarctl completion script for Bash can be generated with `pulsarctl completion bash`. Sourcing this script in your shell enables pulsarctl completion.
+
+However, the pulsarctl completion script depends on `bash-completion` which you thus have to previously install.
+
+> Warning: there are two versions of bash-completion, v1 and v2. V1 is for Bash 3.2 (which is the default on macOS), and v2 is for Bash 4.1+. The pulsarctl completion script doesn’t work correctly with bash-completion v1 and Bash 3.2. It requires bash-completion v2 and Bash 4.1+. Thus, to be able to correctly use pulsarctl completion on macOS, you have to install and use Bash 4.1+ (instructions). The following instructions assume that you use Bash 4.1+ (that is, any Bash version of 4.1 or newer).
+
+#### Install bash-completion
+
+> Note: As mentioned, these instructions assume you use Bash 4.1+, which means you will install bash-completion v2 (in contrast to Bash 3.2 and bash-completion v1, in which case pulsarctl completion won’t work).
+
+You can test if you have bash-completion v2 already installed with `brew list | grep bash`. If not, you can install it with Homebrew:
+
+```bash
+brew install bash-completion@2
+```
+
+As stated in the output of this command, add the following to your ~/.bashrc file:
+
+```bash
+export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
+[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
+```
+
+#### Enable pulsarctl autocompletion
+
+You now have to ensure that the pulsarctl completion script gets sourced in all your shell sessions. There are multiple ways to achieve this:
+
+- First, you can use `bash` into the bash shell.
+
+> Note: If you are using the bash shell, you can ignore it
+
+- Add the completion script to the `/usr/local/etc/bash_completion.d` directory:
+
+```bash
+pulsarctl completion bash >/usr/local/etc/bash_completion.d/pulsarctl.bash
+```
+
+- Source the completion script in your `~/.bashrc` file:
+
+```bash
+echo 'source /usr/local/etc/bash_completion.d/pulsarctl.bash' >> ~/.bashrc
+source ~/.bashrc
+```

--- a/docs/en/enable_completion.md
+++ b/docs/en/enable_completion.md
@@ -1,0 +1,30 @@
+## Enabling shell autocompletion
+
+pulsarctl provides autocompletion support for Bash and Zsh, which can save you a lot of typing.
+
+### Zsh
+
+The pulsarctl completion script for Zsh can be generated with the command `pulsarctl completion zsh`. Sourcing the completion script in your shell enables pulsarctl autocompletion.
+
+To configure your zsh shell, run:
+
+```bash
+mkdir -p ~/.zsh/completion/
+pulsarctl completion zsh > ~/.zsh/completion/_pulsarctl
+```
+
+Include the directory in your $fpath, for example by adding in ~/.zshrc:
+
+```bash
+fpath=($fpath ~/.zsh/completion)
+```
+
+You may have to force rebuild zcompdump:
+
+```bash
+rm -f ~/.zcompdump; compinit
+```
+
+### Bash
+
+

--- a/pkg/ctl/completion/completion.go
+++ b/pkg/ctl/completion/completion.go
@@ -54,9 +54,11 @@ source /dev/stdin <<<"$(pulsarctl completion bash)"
 mkdir -p ~/.zsh/completion/
 pulsarctl completion zsh > ~/.zsh/completion/_pulsarctl
 
-and put the following in ~/.zshrc:
-
+# Include the directory in your $fpath, for example by adding in ~/.zshrc:
 fpath=($fpath ~/.zsh/completion)
+
+# You may have to force rebuild zcompdump:
+rm -f ~/.zcompdump; compinit
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rootCmd.GenZshCompletion(os.Stdout)


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

## Modifications

- Add zsh auto completion docs

Sometimes, we may have to force rebuild `zcompdump`. Output correctly as follows:

![image](https://user-images.githubusercontent.com/20965307/71060944-db3ed200-21a1-11ea-8e9e-381afaaeec42.png)

- Add bash auto completion docs

![image](https://user-images.githubusercontent.com/20965307/71085305-22dd5200-21d2-11ea-9dd4-e8e1cb76359b.png)

- update `README.md`