### PR TITLE
Fix parse wrong http header when receive pulsar header

### DIFF
--- a/pkg/pulsar/subscription.go
+++ b/pkg/pulsar/subscription.go
@@ -181,7 +181,7 @@ func safeRespClose(resp *http.Response) {
 const (
 	PublishTimeHeader = "X-Pulsar-Publish-Time"
 	BatchHeader       = "X-Pulsar-Num-Batch-Message"
-	PropertyPrefix    = "X-Pulsar-PROPERTY-"
+	PropertyPrefix    = "X-Pulsar-Property-"
 )
 
 func handleResp(topic utils.TopicName, resp *http.Response) ([]*utils.Message, error) {


### PR DESCRIPTION
---

Fixes #164

*Motivation*

When peekking a message using pulsarctl, the properties can not receive correctly.
That's because the header is named as Camel when go http client receive the header.

*Modifications*

- Change the header prefix as camel

—-
Will add test after the test framework added. 