### PR TITLE
[issue-171] Improve tab alignment of help text

### DIFF
--- a/pkg/cmdutils/group.go
+++ b/pkg/cmdutils/group.go
@@ -20,6 +20,7 @@ package cmdutils
 import (
 	"fmt"
 	"strings"
+	"text/tabwriter"
 	"unicode"
 
 	"github.com/spf13/cobra"
@@ -91,9 +92,13 @@ func (g *FlagGrouping) Usage(cmd *cobra.Command) error {
 
 	if cmd.HasAvailableSubCommands() {
 		usage = append(usage, "\nCommands:")
+		buf := strings.Builder{}
+		w := tabwriter.NewWriter(&buf, 10, 0, 3, ' ', 0)
 		for _, subCommand := range cmd.Commands() {
-			usage = append(usage, fmt.Sprintf("  %-10s  %s", subCommand.Name(), subCommand.Short))
+			_, _ = fmt.Fprintf(w, "  %s\t%s\n", subCommand.Name(), subCommand.Short)
 		}
+		_ = w.Flush()
+		usage = append(usage, strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")...)
 	}
 
 	if cmd.HasExample() {

--- a/pkg/ctl/functions/create.go
+++ b/pkg/ctl/functions/create.go
@@ -181,7 +181,7 @@ func createFunctionsCmd(vc *cmdutils.VerbCmd) {
 
 	vc.SetDescription(
 		"create",
-		"",
+		"Create a Pulsar Function to run on a Pulsar cluster",
 		desc.ToString(),
 		desc.ExampleToString(),
 		"create",

--- a/pkg/ctl/tenant/delete.go
+++ b/pkg/ctl/tenant/delete.go
@@ -51,10 +51,10 @@ func deleteTenantCmd(vc *cmdutils.VerbCmd) {
 
 	vc.SetDescription(
 		"delete",
-		"d",
+		"Delete a tenant",
 		desc.ToString(),
 		desc.ExampleToString(),
-		"")
+		"delete")
 
 	vc.SetRunFuncWithNameArg(func() error {
 		return doDeleteTenant(vc)


### PR DESCRIPTION
- improve tabstops on help text
- fix help messages on a couple of commands

Closes #171 
Signed-off-by: Eron Wright <ewright@streamnative.io>

New output:
```
Usage: pulsarctl namespaces [flags]

Commands:
  clear-backlog                        Clear backlog for all topics of a namespace
  clear-offload-deletion-lag           Clear offload deletion lag of a namespace
  create                               Create a new namespace
  delete                               Delete a namespace. The namespace needs to be empty
  delete-anti-affinity-group           Delete an anti-affinity group of a namespace
  get-anti-affinity-group              Get the anti-affinity group of a namespace
  get-anti-affinity-namespaces         Get the list of namespaces in the same anti-affinity group.
  get-backlog-quotas                   Get the backlog quota policy of a namespace
  get-clusters                         Get the replicated clusters of a namespace
  get-compaction-threshold             Get compaction threshold of a namespace
  get-dispatch-rate                    Get the default message dispatch rate of a namespace
  get-max-consumers-per-subscription   Get the max consumers per subscription of a namespace
  get-max-consumers-per-topic          Get the max consumers per topic of a namespace
  get-max-producers-per-topic          Get the max producers per topic of namespace
...
```