### PR TITLE
[issue-126] Output formats for 'get' commands

### DIFF
--- a/pkg/cmdutils/output.go
+++ b/pkg/cmdutils/output.go
@@ -158,6 +158,12 @@ func (o OutputContent) Negotiate(format OutputFormat) OutputWritable {
 		if o.text != nil {
 			return o.text
 		}
+		if o.obj != nil {
+			// fallback to a JSON representation
+			return byteOutputFunc(func() ([]byte, error) {
+				return json.MarshalIndent(o.obj(), "", "  ")
+			})
+		}
 	case JSONOutputFormat:
 		if o.obj != nil {
 			return byteOutputFunc(func() ([]byte, error) {

--- a/pkg/cmdutils/output.go
+++ b/pkg/cmdutils/output.go
@@ -131,8 +131,9 @@ func NewOutputContent() *OutputContent {
 	return &OutputContent{}
 }
 
-func (o *OutputContent) WithText(text string) *OutputContent {
-	o.text = OutputWritableFunc(func(w io.Writer) error { _, err := fmt.Fprint(w, text); return err })
+// WithText produces the given formatted string
+func (o *OutputContent) WithText(format string, i ...interface{}) *OutputContent {
+	o.text = OutputWritableFunc(func(w io.Writer) error { _, err := fmt.Fprintf(w, format, i...); return err })
 	return o
 }
 

--- a/pkg/cmdutils/output_test.go
+++ b/pkg/cmdutils/output_test.go
@@ -91,7 +91,10 @@ func TestOutputContent(t *testing.T) {
 			},
 			tests: map[OutputFormat]string{
 				OutputFormat("bad"): "",
-				TextOutputFormat:    "",
+				TextOutputFormat: `[
+  "foo",
+  "bar"
+]`,
 				JSONOutputFormat: `[
   "foo",
   "bar"
@@ -107,7 +110,10 @@ func TestOutputContent(t *testing.T) {
 			},
 			tests: map[OutputFormat]string{
 				OutputFormat("bad"): "",
-				TextOutputFormat:    "",
+				TextOutputFormat: `[
+  "foo",
+  "bar"
+]`,
 				JSONOutputFormat: `[
   "foo",
   "bar"

--- a/pkg/ctl/brokers/config.go
+++ b/pkg/ctl/brokers/config.go
@@ -58,6 +58,8 @@ func getInternalConfigCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFunc(func() error {
 		return doGetInternalConfig(vc)
 	})
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetInternalConfig(vc *cmdutils.VerbCmd) error {
@@ -66,7 +68,8 @@ func doGetInternalConfig(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), brokersData)
+		oc := cmdutils.NewOutputContent().WithObject(brokersData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/brokers/get_all_dynamic_config.go
+++ b/pkg/ctl/brokers/get_all_dynamic_config.go
@@ -54,6 +54,8 @@ func getAllDynamicConfigsCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFunc(func() error {
 		return doGetAllDynamicConfigs(vc)
 	})
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetAllDynamicConfigs(vc *cmdutils.VerbCmd) error {
@@ -62,7 +64,8 @@ func doGetAllDynamicConfigs(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), brokersData)
+		oc := cmdutils.NewOutputContent().WithObject(brokersData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/brokers/get_runtime_config.go
+++ b/pkg/ctl/brokers/get_runtime_config.go
@@ -60,6 +60,8 @@ func getRuntimeConfigCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFunc(func() error {
 		return doGetRuntimeConfig(vc)
 	})
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetRuntimeConfig(vc *cmdutils.VerbCmd) error {
@@ -68,7 +70,8 @@ func doGetRuntimeConfig(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), brokersData)
+		oc := cmdutils.NewOutputContent().WithObject(brokersData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/brokers/namespaces.go
+++ b/pkg/ctl/brokers/namespaces.go
@@ -93,6 +93,7 @@ func getOwnedNamespacesCmd(vc *cmdutils.VerbCmd) {
 
 		cobra.MarkFlagRequired(flagSet, "url")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doOwnedNamespaces(vc *cmdutils.VerbCmd, brokerData *utils.BrokerData) error {
@@ -106,7 +107,8 @@ func doOwnedNamespaces(vc *cmdutils.VerbCmd, brokerData *utils.BrokerData) error
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), namespaces)
+		oc := cmdutils.NewOutputContent().WithObject(namespaces)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/cluster/get.go
+++ b/pkg/ctl/cluster/get.go
@@ -18,8 +18,6 @@
 package cluster
 
 import (
-	"encoding/json"
-
 	"github.com/pkg/errors"
 	"github.com/streamnative/pulsarctl/pkg/cmdutils"
 )
@@ -64,6 +62,8 @@ func getClusterDataCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetClusterData(vc)
 	}, "the cluster name is not specified or the cluster name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetClusterData(vc *cmdutils.VerbCmd) error {
@@ -75,11 +75,8 @@ func doGetClusterData(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	clusterData, err := admin.Clusters().Get(clusterName)
 	if err == nil {
-		s, err := json.MarshalIndent(clusterData, "", "    ")
-		if err != nil {
-			return err
-		}
-		vc.Command.Println(string(s))
+		oc := cmdutils.NewOutputContent().WithObject(clusterData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/cluster/get_failure_domain.go
+++ b/pkg/ctl/cluster/get_failure_domain.go
@@ -58,6 +58,8 @@ func getFailureDomainCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithMultiNameArgs(func() error {
 		return doGetFailureDomain(vc)
 	}, checkFailureDomainArgs)
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetFailureDomain(vc *cmdutils.VerbCmd) error {
@@ -72,7 +74,8 @@ func doGetFailureDomain(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	resFailureDomain, err := admin.Clusters().GetFailureDomain(clusterName, domainName)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), resFailureDomain)
+		oc := cmdutils.NewOutputContent().WithObject(resFailureDomain)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/cluster/list_failure_domain.go
+++ b/pkg/ctl/cluster/list_failure_domain.go
@@ -61,6 +61,8 @@ func listFailureDomainCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doListFailureDomain(vc)
 	}, "the cluster name is not specified or the cluster name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doListFailureDomain(vc *cmdutils.VerbCmd) error {
@@ -74,7 +76,8 @@ func doListFailureDomain(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	domainData, err := admin.Clusters().ListFailureDomains(clusterName)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), domainData)
+		oc := cmdutils.NewOutputContent().WithObject(domainData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/functions/get.go
+++ b/pkg/ctl/functions/get.go
@@ -123,6 +123,7 @@ func getFunctionsCmd(vc *cmdutils.VerbCmd) {
 			"",
 			"The name of a Pulsar Function")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doGetFunctions(vc *cmdutils.VerbCmd, funcData *utils.FunctionData) error {
@@ -137,7 +138,8 @@ func doGetFunctions(vc *cmdutils.VerbCmd, funcData *utils.FunctionData) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), functionConfig)
+		oc := cmdutils.NewOutputContent().WithObject(functionConfig)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/functions/querystate.go
+++ b/pkg/ctl/functions/querystate.go
@@ -153,6 +153,7 @@ func querystateFunctionsCmd(vc *cmdutils.VerbCmd) {
 		cobra.MarkFlagRequired(flagSet, "key")
 		cobra.MarkFlagRequired(flagSet, "name")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doQueryStateFunction(vc *cmdutils.VerbCmd, funcData *utils.FunctionData) error {
@@ -169,7 +170,11 @@ func doQueryStateFunction(vc *cmdutils.VerbCmd, funcData *utils.FunctionData) er
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 		} else {
-			cmdutils.PrintJSON(vc.Command.OutOrStdout(), functionState)
+			oc := cmdutils.NewOutputContent().WithObject(functionState)
+			err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+			if err != nil {
+				return err
+			}
 		}
 
 		if funcData.Watch {

--- a/pkg/ctl/functions/stats.go
+++ b/pkg/ctl/functions/stats.go
@@ -172,6 +172,7 @@ func statsFunctionsCmd(vc *cmdutils.VerbCmd) {
 			"",
 			"The function instanceId (Get-stats of all instances if instance-id is not provided)")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doStatsFunction(vc *cmdutils.VerbCmd, funcData *utils.FunctionData) error {
@@ -190,15 +191,24 @@ func doStatsFunction(vc *cmdutils.VerbCmd, funcData *utils.FunctionData) error {
 			funcData.Tenant, funcData.Namespace, funcData.FuncName, instanceID)
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
+			return nil
 		}
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), functionInstanceStatsData)
+		oc := cmdutils.NewOutputContent().WithObject(functionInstanceStatsData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+		if err != nil {
+			return err
+		}
 	} else {
 		functionStats, err := admin.Functions().GetFunctionStats(funcData.Tenant, funcData.Namespace, funcData.FuncName)
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
+			return nil
 		}
-
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), functionStats)
+		oc := cmdutils.NewOutputContent().WithObject(functionStats)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+		if err != nil {
+			return err
+		}
 	}
 
 	return err

--- a/pkg/ctl/functions/status.go
+++ b/pkg/ctl/functions/status.go
@@ -143,6 +143,7 @@ func statusFunctionsCmd(vc *cmdutils.VerbCmd) {
 			"",
 			"The function instanceId (Get-status of all instances if instance-id is not provided)")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doStatusFunction(vc *cmdutils.VerbCmd, funcData *utils.FunctionData) error {
@@ -161,14 +162,24 @@ func doStatusFunction(vc *cmdutils.VerbCmd, funcData *utils.FunctionData) error 
 			funcData.Tenant, funcData.Namespace, funcData.FuncName, instanceID)
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
+			return nil
 		}
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), functionInstanceStatusData)
+		oc := cmdutils.NewOutputContent().WithObject(functionInstanceStatusData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+		if err != nil {
+			return err
+		}
 	} else {
 		functionStatus, err := admin.Functions().GetFunctionStatus(funcData.Tenant, funcData.Namespace, funcData.FuncName)
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
+			return nil
 		}
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), functionStatus)
+		oc := cmdutils.NewOutputContent().WithObject(functionStatus)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+		if err != nil {
+			return err
+		}
 	}
 
 	return err

--- a/pkg/ctl/functionsworker/function_stats.go
+++ b/pkg/ctl/functionsworker/function_stats.go
@@ -54,6 +54,8 @@ func functionsStats(vc *cmdutils.VerbCmd) {
 	vc.SetRunFunc(func() error {
 		return doFunctionStats(vc)
 	})
+
+	vc.EnableOutputFlagSet()
 }
 
 func doFunctionStats(vc *cmdutils.VerbCmd) error {
@@ -62,7 +64,8 @@ func doFunctionStats(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), fnStats)
+		oc := cmdutils.NewOutputContent().WithObject(fnStats)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/functionsworker/get_cluster.go
+++ b/pkg/ctl/functionsworker/get_cluster.go
@@ -60,6 +60,8 @@ func getCluster(vc *cmdutils.VerbCmd) {
 	vc.SetRunFunc(func() error {
 		return doGetCluster(vc)
 	})
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetCluster(vc *cmdutils.VerbCmd) error {
@@ -68,7 +70,8 @@ func doGetCluster(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), workersInfo)
+		oc := cmdutils.NewOutputContent().WithObject(workersInfo)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/functionsworker/get_cluster_leader.go
+++ b/pkg/ctl/functionsworker/get_cluster_leader.go
@@ -58,6 +58,8 @@ func getClusterLeader(vc *cmdutils.VerbCmd) {
 	vc.SetRunFunc(func() error {
 		return doGetClusterLeader(vc)
 	})
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetClusterLeader(vc *cmdutils.VerbCmd) error {
@@ -66,7 +68,8 @@ func doGetClusterLeader(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), workerInfo)
+		oc := cmdutils.NewOutputContent().WithObject(workerInfo)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/functionsworker/get_function_assignments.go
+++ b/pkg/ctl/functionsworker/get_function_assignments.go
@@ -54,6 +54,8 @@ func getFunctionAssignments(vc *cmdutils.VerbCmd) {
 	vc.SetRunFunc(func() error {
 		return doGetFunctionAssignments(vc)
 	})
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetFunctionAssignments(vc *cmdutils.VerbCmd) error {
@@ -62,7 +64,8 @@ func doGetFunctionAssignments(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), fnStats)
+		oc := cmdutils.NewOutputContent().WithObject(fnStats)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/functionsworker/monitoring_metrics.go
+++ b/pkg/ctl/functionsworker/monitoring_metrics.go
@@ -74,6 +74,8 @@ func monitoringMetrics(vc *cmdutils.VerbCmd) {
 	vc.SetRunFunc(func() error {
 		return doMonitoringMetrics(vc)
 	})
+
+	vc.EnableOutputFlagSet()
 }
 
 func doMonitoringMetrics(vc *cmdutils.VerbCmd) error {
@@ -82,7 +84,8 @@ func doMonitoringMetrics(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), metrics)
+		oc := cmdutils.NewOutputContent().WithObject(metrics)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/namespace/permissions.go
+++ b/pkg/ctl/namespace/permissions.go
@@ -58,6 +58,8 @@ func GetPermissionsCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetPermissions(vc)
 	}, "the namespace name is not specified or the namespace name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetPermissions(vc *cmdutils.VerbCmd) error {
@@ -74,7 +76,8 @@ func doGetPermissions(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	data, err := admin.Namespaces().GetNamespacePermissions(*ns)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), data)
+		oc := cmdutils.NewOutputContent().WithObject(data)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/namespace/policies.go
+++ b/pkg/ctl/namespace/policies.go
@@ -128,6 +128,8 @@ func getPolicies(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetPolicies(vc)
 	}, "the namespace name is not specified or the namespace name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetPolicies(vc *cmdutils.VerbCmd) error {
@@ -135,7 +137,8 @@ func doGetPolicies(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	policies, err := admin.Namespaces().GetPolicies(namespace)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), policies)
+		oc := cmdutils.NewOutputContent().WithObject(policies)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/nsisolationpolicy/broker.go
+++ b/pkg/ctl/nsisolationpolicy/broker.go
@@ -74,6 +74,8 @@ func getBrokerWithPolicies(vc *cmdutils.VerbCmd) {
 		}
 		return nil
 	})
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetBrokerWithPolicies(vc *cmdutils.VerbCmd) error {
@@ -85,7 +87,8 @@ func doGetBrokerWithPolicies(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), nsIsolationData)
+		oc := cmdutils.NewOutputContent().WithObject(nsIsolationData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/nsisolationpolicy/brokers.go
+++ b/pkg/ctl/nsisolationpolicy/brokers.go
@@ -74,6 +74,8 @@ func getAllBrokersWithPolicies(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetAllBrokersWithPolicies(vc)
 	}, "the cluster name is not specified or the cluster name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetAllBrokersWithPolicies(vc *cmdutils.VerbCmd) error {
@@ -84,7 +86,8 @@ func doGetAllBrokersWithPolicies(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), nsIsolationData)
+		oc := cmdutils.NewOutputContent().WithObject(nsIsolationData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/nsisolationpolicy/get.go
+++ b/pkg/ctl/nsisolationpolicy/get.go
@@ -77,6 +77,8 @@ func getNsIsolationPolicy(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithMultiNameArgs(func() error {
 		return doGetNsIsolationPolicy(vc)
 	}, checkNsIsolationPolicyArgs)
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetNsIsolationPolicy(vc *cmdutils.VerbCmd) error {
@@ -88,7 +90,8 @@ func doGetNsIsolationPolicy(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), nsIsolationData)
+		oc := cmdutils.NewOutputContent().WithObject(nsIsolationData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/nsisolationpolicy/list.go
+++ b/pkg/ctl/nsisolationpolicy/list.go
@@ -75,6 +75,8 @@ func getNsIsolationPolicies(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetNsIsolationPolicies(vc)
 	}, "the cluster name is not specified or the cluster name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetNsIsolationPolicies(vc *cmdutils.VerbCmd) error {
@@ -85,7 +87,8 @@ func doGetNsIsolationPolicies(vc *cmdutils.VerbCmd) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), nsIsolationData)
+		oc := cmdutils.NewOutputContent().WithObject(nsIsolationData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/resourcequotas/get.go
+++ b/pkg/ctl/resourcequotas/get.go
@@ -74,11 +74,16 @@ func getResourceQuota(vc *cmdutils.VerbCmd) {
 		}
 		return nil
 	})
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetResourceQuota(vc *cmdutils.VerbCmd) error {
 	var namespace, bundle string
 	if len(vc.NameArgs) > 0 {
+		if len(vc.NameArgs) < 2 {
+			return errors.New("Namespace and bundle must be provided together")
+		}
 		namespace = vc.NameArgs[0]
 		bundle = vc.NameArgs[1]
 	}
@@ -92,7 +97,11 @@ func doGetResourceQuota(vc *cmdutils.VerbCmd) error {
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 		} else {
-			cmdutils.PrintJSON(vc.Command.OutOrStdout(), resourceQuotaData)
+			oc := cmdutils.NewOutputContent().WithObject(resourceQuotaData)
+			err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+			if err != nil {
+				return err
+			}
 		}
 	case bundle != "" && namespace != "":
 		nsName, err := utils.GetNamespaceName(namespace)
@@ -104,7 +113,11 @@ func doGetResourceQuota(vc *cmdutils.VerbCmd) error {
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 		} else {
-			cmdutils.PrintJSON(vc.Command.OutOrStdout(), resourceQuotaData)
+			oc := cmdutils.NewOutputContent().WithObject(resourceQuotaData)
+			err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+			if err != nil {
+				return err
+			}
 		}
 	default:
 		return errors.New("Namespace and bundle must be provided together")

--- a/pkg/ctl/sinks/get.go
+++ b/pkg/ctl/sinks/get.go
@@ -110,6 +110,7 @@ func getSinksCmd(vc *cmdutils.VerbCmd) {
 			"",
 			"The sink's name")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doGetSinks(vc *cmdutils.VerbCmd, sinkData *utils.SinkData) error {
@@ -124,7 +125,8 @@ func doGetSinks(vc *cmdutils.VerbCmd, sinkData *utils.SinkData) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), sinkConfig)
+		oc := cmdutils.NewOutputContent().WithObject(sinkConfig)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/sinks/status.go
+++ b/pkg/ctl/sinks/status.go
@@ -120,6 +120,7 @@ func statusSinksCmd(vc *cmdutils.VerbCmd) {
 			"",
 			"The sink instanceId (stop all instances if instance-id is not provided)")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doStatusSink(vc *cmdutils.VerbCmd, sinkData *utils.SinkData) error {
@@ -138,14 +139,24 @@ func doStatusSink(vc *cmdutils.VerbCmd, sinkData *utils.SinkData) error {
 			sinkData.Tenant, sinkData.Namespace, sinkData.Name, instanceID)
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
+			return nil
 		}
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), sinkInstanceStatusData)
+		oc := cmdutils.NewOutputContent().WithObject(sinkInstanceStatusData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+		if err != nil {
+			return err
+		}
 	} else {
 		sinkStatus, err := admin.Sinks().GetSinkStatus(sinkData.Tenant, sinkData.Namespace, sinkData.Name)
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
+			return nil
 		}
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), sinkStatus)
+		oc := cmdutils.NewOutputContent().WithObject(sinkStatus)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+		if err != nil {
+			return err
+		}
 	}
 
 	return err

--- a/pkg/ctl/sources/get.go
+++ b/pkg/ctl/sources/get.go
@@ -105,6 +105,7 @@ func getSourcesCmd(vc *cmdutils.VerbCmd) {
 			"",
 			"The source's name")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doGetSources(vc *cmdutils.VerbCmd, sourceData *utils.SourceData) error {
@@ -119,7 +120,8 @@ func doGetSources(vc *cmdutils.VerbCmd, sourceData *utils.SourceData) error {
 	if err != nil {
 		cmdutils.PrintError(vc.Command.OutOrStderr(), err)
 	} else {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), sourceConfig)
+		oc := cmdutils.NewOutputContent().WithObject(sourceConfig)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/sources/status.go
+++ b/pkg/ctl/sources/status.go
@@ -120,6 +120,7 @@ func statusSourcesCmd(vc *cmdutils.VerbCmd) {
 			"",
 			"The source instanceId (stop all instances if instance-id is not provided)")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doStatusSource(vc *cmdutils.VerbCmd, sourceData *utils.SourceData) error {
@@ -138,14 +139,24 @@ func doStatusSource(vc *cmdutils.VerbCmd, sourceData *utils.SourceData) error {
 			sourceData.Tenant, sourceData.Namespace, sourceData.Name, instanceID)
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
+			return nil
 		}
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), sourceInstanceStatusData)
+		oc := cmdutils.NewOutputContent().WithObject(sourceInstanceStatusData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+		if err != nil {
+			return err
+		}
 	} else {
 		sourceStatus, err := admin.Sources().GetSourceStatus(sourceData.Tenant, sourceData.Namespace, sourceData.Name)
 		if err != nil {
 			cmdutils.PrintError(vc.Command.OutOrStderr(), err)
+			return nil
 		}
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), sourceStatus)
+		oc := cmdutils.NewOutputContent().WithObject(sourceStatus)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+		if err != nil {
+			return err
+		}
 	}
 
 	return err

--- a/pkg/ctl/tenant/get.go
+++ b/pkg/ctl/tenant/get.go
@@ -62,6 +62,8 @@ func getTenantCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetTenant(vc)
 	}, "the tenant name is not specified or the tenant name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetTenant(vc *cmdutils.VerbCmd) error {
@@ -73,7 +75,8 @@ func doGetTenant(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	data, err := admin.Tenants().Get(vc.NameArg)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), data)
+		oc := cmdutils.NewOutputContent().WithObject(data)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/topic/bundle_range.go
+++ b/pkg/ctl/topic/bundle_range.go
@@ -57,6 +57,8 @@ func GetBundleRangeCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetBundleRange(vc)
 	}, "the topic name is not specified or the topic name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetBundleRange(vc *cmdutils.VerbCmd) error {
@@ -73,7 +75,10 @@ func doGetBundleRange(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	bundleRange, err := admin.Topics().GetBundleRange(*topic)
 	if err == nil {
-		vc.Command.Printf("The bundle range of the topic %s is: %s\n", topic.String(), bundleRange)
+		oc := cmdutils.NewOutputContent().
+			WithObject(bundleRange).
+			WithText("The bundle range of the topic %s is: %s\n", topic.String(), bundleRange)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/topic/get.go
+++ b/pkg/ctl/topic/get.go
@@ -59,6 +59,8 @@ func GetTopicCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetTopic(vc)
 	}, "the topic name is not specified or the topic name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetTopic(vc *cmdutils.VerbCmd) error {
@@ -75,7 +77,8 @@ func doGetTopic(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	meta, err := admin.Topics().GetMetadata(*topic)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), meta)
+		oc := cmdutils.NewOutputContent().WithObject(meta)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/topic/get_permissions.go
+++ b/pkg/ctl/topic/get_permissions.go
@@ -61,6 +61,8 @@ func GetPermissionsCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetPermissions(vc)
 	}, "the topic name is not specified or the topic name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetPermissions(vc *cmdutils.VerbCmd) error {
@@ -77,7 +79,8 @@ func doGetPermissions(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	permissions, err := admin.Topics().GetPermissions(*topic)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), permissions)
+		oc := cmdutils.NewOutputContent().WithObject(permissions)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/topic/internal.go
+++ b/pkg/ctl/topic/internal.go
@@ -95,6 +95,8 @@ func GetInternalInfoCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetInternalInfo(vc)
 	}, "the topic name is not specified or the topic name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doGetInternalInfo(vc *cmdutils.VerbCmd) error {
@@ -111,7 +113,8 @@ func doGetInternalInfo(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	info, err := admin.Topics().GetInternalInfo(*topic)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), info)
+		oc := cmdutils.NewOutputContent().WithObject(info)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/topic/last_messageId.go
+++ b/pkg/ctl/topic/last_messageId.go
@@ -87,6 +87,7 @@ func GetLastMessageIDCmd(vc *cmdutils.VerbCmd) {
 		set.IntVarP(&partition, "partition", "p", -1,
 			"The partitioned topic index value")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doGetLastMessageID(vc *cmdutils.VerbCmd, partition int) error {
@@ -110,7 +111,8 @@ func doGetLastMessageID(vc *cmdutils.VerbCmd, partition int) error {
 	admin := cmdutils.NewPulsarClient()
 	messageID, err := admin.Topics().GetLastMessageID(*topic)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), messageID)
+		oc := cmdutils.NewOutputContent().WithObject(messageID)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err

--- a/pkg/ctl/topic/lookup_topic.go
+++ b/pkg/ctl/topic/lookup_topic.go
@@ -62,6 +62,8 @@ func LookUpTopicCmd(vc *cmdutils.VerbCmd) {
 	vc.SetRunFuncWithNameArg(func() error {
 		return doLookupTopic(vc)
 	}, "the topic name is not specified or the topic name is specified more than one")
+
+	vc.EnableOutputFlagSet()
 }
 
 func doLookupTopic(vc *cmdutils.VerbCmd) error {
@@ -78,7 +80,8 @@ func doLookupTopic(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	lookup, err := admin.Topics().Lookup(*topic)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), lookup)
+		oc := cmdutils.NewOutputContent().WithObject(lookup)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/topic/stats.go
+++ b/pkg/ctl/topic/stats.go
@@ -153,6 +153,7 @@ func GetStatsCmd(vc *cmdutils.VerbCmd) {
 		set.BoolVarP(&perPartition, "per-partition", "", false,
 			"Get the per partition topic stats")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doGetStats(vc *cmdutils.VerbCmd, partitionedTopic, perPartition bool) error {
@@ -171,14 +172,16 @@ func doGetStats(vc *cmdutils.VerbCmd, partitionedTopic, perPartition bool) error
 	if partitionedTopic {
 		stats, err := admin.Topics().GetPartitionedStats(*topic, perPartition)
 		if err == nil {
-			cmdutils.PrintJSON(vc.Command.OutOrStdout(), stats)
+			oc := cmdutils.NewOutputContent().WithObject(stats)
+			err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 		}
 		return err
 	}
 
 	topicStats, err := admin.Topics().GetStats(*topic)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), topicStats)
+		oc := cmdutils.NewOutputContent().WithObject(topicStats)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 	return err
 }

--- a/pkg/ctl/topic/stats_internal.go
+++ b/pkg/ctl/topic/stats_internal.go
@@ -99,6 +99,7 @@ func GetInternalStatsCmd(vc *cmdutils.VerbCmd) {
 		set.IntVarP(&partition, "partition", "p", -1,
 			"The partitioned topic index value")
 	})
+	vc.EnableOutputFlagSet()
 }
 
 func doGetInternalStats(vc *cmdutils.VerbCmd, partition int) error {
@@ -122,7 +123,8 @@ func doGetInternalStats(vc *cmdutils.VerbCmd, partition int) error {
 	admin := cmdutils.NewPulsarClient()
 	stats, err := admin.Topics().GetInternalStats(*topic)
 	if err == nil {
-		cmdutils.PrintJSON(vc.Command.OutOrStdout(), stats)
+		oc := cmdutils.NewOutputContent().WithObject(stats)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 	}
 
 	return err


### PR DESCRIPTION
_This is part 2 of a series of PRs to support multiple output formats for relevant commands._

This PR implements output formats for most 'get' commands (i.e. any command whose main purpose is to get information).   Most commands simply produce JSON output today, and that isn't changing here, but all such commands now produce YAML too.

Some commands do produce a different `text` vs `json` rendition, for example:
```
$ pulsarctl topics compact-status public/default/topic-14 -o text
Compacting the topic persistent://public/default/topic-14 is not running

$ pulsarctl topics compact-status public/default/topic-14 -o json
{
  "status": "NOT_RUN",
  "lastError": ""
}

$ pulsarctl topics compact-status public/default/topic-14 -o json | jq .status
"NOT_RUN"
```

Deferred:
- `pulsarctl broker-stats ...`
- `pulsarctl subscriptions peek`
- `pulsarctl token show|validate`
- `pulsarctl namespaces ...` (policy-related getters; use `namespaces policies` command)
- `bkctl`

Closes #126.