### PR TITLE
Automatically use a context when it is added

### DIFF
--- a/pkg/ctl/context/create_context.go
+++ b/pkg/ctl/context/create_context.go
@@ -83,6 +83,7 @@ func doRunSetContext(vc *cmdutils.VerbCmd, o *createContextOptions) error {
 	context, authInfo := o.modifyContextConf(*startingStanza, *startingAuth)
 	config.Contexts[name] = &context
 	config.AuthInfos[name] = &authInfo
+	config.CurrentContext = name
 
 	if err := internal.ModifyConfig(o.access, *config, true); err != nil {
 		return err

--- a/pkg/ctl/context/create_context_test.go
+++ b/pkg/ctl/context/create_context_test.go
@@ -42,6 +42,8 @@ func TestSetContextCmd(t *testing.T) {
 	out, execErr, err := TestConfigCommands(deleteContextCmd, delArgs)
 	assert.Nil(t, err)
 	assert.Nil(t, execErr)
+	warnOut := "warning: this removed your active context, " +
+		"use \"pulsarctl context use\" to select a different one\n"
 	expectedOut := fmt.Sprintf("deleted context test-set-context from %s\n", path)
-	assert.Equal(t, expectedOut, out.String())
+	assert.Equal(t, warnOut+expectedOut, out.String())
 }

--- a/pkg/ctl/context/create_context_test.go
+++ b/pkg/ctl/context/create_context_test.go
@@ -19,6 +19,7 @@ package context
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
@@ -28,6 +29,7 @@ import (
 func TestSetContextCmd(t *testing.T) {
 	home := utils.HomeDir()
 	path := fmt.Sprintf("%s/.config/pulsar/config", home)
+	defer os.Remove(path)
 
 	setArgs := []string{"set", "test-set-context"}
 	out, _, err := TestConfigCommands(setContextCmd, setArgs)

--- a/pkg/ctl/context/current_context_test.go
+++ b/pkg/ctl/context/current_context_test.go
@@ -27,8 +27,8 @@ func TestCurrentContextCmd(t *testing.T) {
 	currentArgs := []string{"current"}
 	out, execErr, err := TestConfigCommands(currentContextCmd, currentArgs)
 	assert.Nil(t, err)
-	assert.Equal(t, "test-set-context\n", out.String())
-	assert.Nil(t, execErr)
+	assert.Equal(t, "", out.String())
+	assert.Equal(t, "current-context is not set", execErr.Error())
 
 	setArgs := []string{"set", "test-current-context"}
 	out, execErr, err = TestConfigCommands(setContextCmd, setArgs)

--- a/pkg/ctl/context/current_context_test.go
+++ b/pkg/ctl/context/current_context_test.go
@@ -27,8 +27,8 @@ func TestCurrentContextCmd(t *testing.T) {
 	currentArgs := []string{"current"}
 	out, execErr, err := TestConfigCommands(currentContextCmd, currentArgs)
 	assert.Nil(t, err)
-	assert.Equal(t, "", out.String())
-	assert.Equal(t, "current-context is not set", execErr.Error())
+	assert.Equal(t, "test-set-context\n", out.String())
+	assert.Nil(t, execErr)
 
 	setArgs := []string{"set", "test-current-context"}
 	out, execErr, err = TestConfigCommands(setContextCmd, setArgs)

--- a/pkg/ctl/context/delete_context_test.go
+++ b/pkg/ctl/context/delete_context_test.go
@@ -46,6 +46,8 @@ func TestDeleteContextCmd(t *testing.T) {
 	out, execErr, err = TestConfigCommands(deleteContextCmd, delArgs)
 	assert.Nil(t, err)
 	assert.Nil(t, execErr)
+	warnOut := "warning: this removed your active context, " +
+		"use \"pulsarctl context use\" to select a different one\n"
 	expectedOut := fmt.Sprintf("deleted context test-delete-context from %s\n", path)
-	assert.Equal(t, expectedOut, out.String())
+	assert.Equal(t, warnOut+expectedOut, out.String())
 }

--- a/pkg/ctl/context/delete_context_test.go
+++ b/pkg/ctl/context/delete_context_test.go
@@ -19,6 +19,7 @@ package context
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
@@ -28,6 +29,7 @@ import (
 func TestDeleteContextCmd(t *testing.T) {
 	home := utils.HomeDir()
 	path := fmt.Sprintf("%s/.config/pulsar/config", home)
+	defer os.Remove(path)
 
 	delArgs := []string{"delete", "test-delete-context"}
 	out, execErr, err := TestConfigCommands(deleteContextCmd, delArgs)

--- a/pkg/ctl/context/rename_context_test.go
+++ b/pkg/ctl/context/rename_context_test.go
@@ -19,6 +19,7 @@ package context
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
@@ -28,6 +29,7 @@ import (
 func TestRenameContextCmd(t *testing.T) {
 	home := utils.HomeDir()
 	path := fmt.Sprintf("%s/.config/pulsar/config", home)
+	defer os.Remove(path)
 
 	renameArgs := []string{"rename", "test-old-context", "test-new-context"}
 	out, execErr, err := TestConfigCommands(renameContextCmd, renameArgs)

--- a/pkg/ctl/context/rename_context_test.go
+++ b/pkg/ctl/context/rename_context_test.go
@@ -52,6 +52,8 @@ func TestRenameContextCmd(t *testing.T) {
 	out, execErr, err = TestConfigCommands(deleteContextCmd, delArgs)
 	assert.Nil(t, err)
 	assert.Nil(t, execErr)
+	warnOut := "warning: this removed your active context, " +
+		"use \"pulsarctl context use\" to select a different one\n"
 	expectedOut := fmt.Sprintf("deleted context test-new-context from %s\n", path)
-	assert.Equal(t, expectedOut, out.String())
+	assert.Equal(t, warnOut+expectedOut, out.String())
 }


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes: #173

- Automatically use a context when it is added