### PR TITLE
[Issue 185] Fix `pulsarctl schemas get --version 0` produces incorrect results

### DIFF
--- a/pkg/ctl/schemas/get.go
+++ b/pkg/ctl/schemas/get.go
@@ -123,7 +123,7 @@ func doGetSchema(vc *cmdutils.VerbCmd, schemaData *utils.SchemaData) error {
 	topic := vc.NameArg
 
 	admin := cmdutils.NewPulsarClient()
-	if schemaData.Version == 0 {
+	if !vc.Command.Flag("version").Changed {
 		schemaInfoWithVersion, err := admin.Schemas().GetSchemaInfoWithVersion(topic)
 		if err == nil {
 			oc := cmdutils.NewOutputContent().


### PR DESCRIPTION
Fixes #185

*Motivation*

Fix issue #185.

---

There is no test to verify this change because we can not create a topic with schema in the pulsarctl.
