### PR TITLE
Separate functions related tests to a new CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,35 +25,15 @@ jobs:
 
     - name: Get dependencies
       run: |
-        wget https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/0.10.2.1/kafka-clients-0.10.2.1.jar
-        wget https://archive.apache.org/dist/pulsar/pulsar-2.4.0/connectors/pulsar-io-kafka-2.4.0.nar
-        wget https://archive.apache.org/dist/pulsar/pulsar-2.4.0/connectors/pulsar-io-jdbc-2.4.0.nar
-
-        docker network create kafka-pulsar
-        docker pull wurstmeister/zookeeper
-        docker run -d -it -p 2181:2181 --name pulsar-kafka-zookeeper --network kafka-pulsar wurstmeister/zookeeper
-        docker pull wurstmeister/kafka:2.11-1.0.2
-        docker run -d -it --network kafka-pulsar -p 6667:6667 -p 9092:9092 -e KAFKA_ADVERTISED_HOST_NAME=pulsar-kafka -e KAFKA_ZOOKEEPER_CONNECT=pulsar-kafka-zookeeper:2181 --name pulsar-kafka wurstmeister/kafka:2.11-1.0.2
-
-        docker pull apachepulsar/pulsar:2.4.0
         docker run -d -p 8080:8080 -p 6650:6650 -v ${PWD}:/pulsar_test -v ${PWD}/data:/pulsar/data --name pulsarctl apachepulsar/pulsar:latest bin/pulsar standalone
-        docker cp pulsar-io-kafka-2.4.0.nar pulsarctl:/pulsar
-        docker cp pulsar-io-jdbc-2.4.0.nar pulsarctl:/pulsar
-        docker cp pulsarctl:/pulsar/pulsar-io-kafka-2.4.0.nar ${PWD}/test/sources/
-        docker cp pulsarctl:/pulsar/pulsar-io-jdbc-2.4.0.nar ${PWD}/test/sinks/
-        docker cp ${PWD}/test/sources/kafkaSourceConfig.yaml pulsarctl:/pulsar/conf
-        docker cp ${PWD}/test/sinks/mysql-jdbc-sink.yaml pulsarctl:/pulsar/conf
-        docker cp kafka-clients-0.10.2.1.jar pulsarctl:/pulsar/lib
-        docker cp pulsarctl:/pulsar/examples/api-examples.jar ${PWD}/test/functions/
 
-        ls -al test/functions/
         sleep 10
 
     - name: Build
       run: go build .
-      
+
     - name: Test
       run: |
         docker ps
         ./pulsarctl clusters list
-        go test -v $(go list ./... | grep -v bookkeeper | grep -v bkctl)
+        go test -v $(go list ./... | grep -v bookkeeper | grep -v bkctl | grep -v functions | grep -v sources | grep -v sinks)

--- a/.github/workflows/pulsarctl-function-test.yml
+++ b/.github/workflows/pulsarctl-function-test.yml
@@ -1,0 +1,64 @@
+name: Pulsarctl Functions Tests
+on:
+  pull_request:
+    branches:
+      - master
+    path-ignores:
+      - 'docs/**'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        wget https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/0.10.2.1/kafka-clients-0.10.2.1.jar
+        wget https://archive.apache.org/dist/pulsar/pulsar-2.4.0/connectors/pulsar-io-kafka-2.4.0.nar
+        wget https://archive.apache.org/dist/pulsar/pulsar-2.4.0/connectors/pulsar-io-jdbc-2.4.0.nar
+
+        docker network create kafka-pulsar
+        docker pull wurstmeister/zookeeper
+        docker run -d -it -p 2181:2181 --name pulsar-kafka-zookeeper --network kafka-pulsar wurstmeister/zookeeper
+        docker pull wurstmeister/kafka:2.11-1.0.2
+        docker run -d -it --network kafka-pulsar -p 6667:6667 -p 9092:9092 -e KAFKA_ADVERTISED_HOST_NAME=pulsar-kafka -e KAFKA_ZOOKEEPER_CONNECT=pulsar-kafka-zookeeper:2181 --name pulsar-kafka wurstmeister/kafka:2.11-1.0.2
+
+        docker pull apachepulsar/pulsar:2.4.0
+        docker run -d -p 8080:8080 -p 6650:6650 -v ${PWD}:/pulsar_test -v ${PWD}/data:/pulsar/data --name pulsarctl apachepulsar/pulsar:latest bin/pulsar standalone
+        docker cp pulsar-io-kafka-2.4.0.nar pulsarctl:/pulsar
+        docker cp pulsar-io-jdbc-2.4.0.nar pulsarctl:/pulsar
+        docker cp pulsarctl:/pulsar/pulsar-io-kafka-2.4.0.nar ${PWD}/test/sources/
+        docker cp pulsarctl:/pulsar/pulsar-io-jdbc-2.4.0.nar ${PWD}/test/sinks/
+        docker cp ${PWD}/test/sources/kafkaSourceConfig.yaml pulsarctl:/pulsar/conf
+        docker cp ${PWD}/test/sinks/mysql-jdbc-sink.yaml pulsarctl:/pulsar/conf
+        docker cp kafka-clients-0.10.2.1.jar pulsarctl:/pulsar/lib
+        docker cp pulsarctl:/pulsar/examples/api-examples.jar ${PWD}/test/functions/
+
+        ls -al test/functions/
+
+    - name: Waiting for function worker service
+      run: ./test/script/check.sh functionWorker
+
+    - name: Build
+      run: go build .
+      
+    - name: Function tests
+      run: go test -test.timeout 2m -v $(go list ./... | grep functions)
+
+    - name: Sink tests
+      run: go test -test.timeout 5m -v $(go list ./... | grep sinks)
+
+    - name: Source tests
+      run: go test -test.timeout 2m -v $(go list ./... | grep sources)

--- a/pkg/ctl/functions/putstate_test.go
+++ b/pkg/ctl/functions/putstate_test.go
@@ -33,7 +33,7 @@ import (
 func TestStateFunctions(t *testing.T) {
 	basePath, err := getDirHelp()
 	if basePath == "" || err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	t.Logf("base path: %s", basePath)
 	args := []string{"create",
@@ -49,7 +49,7 @@ func TestStateFunctions(t *testing.T) {
 	out, execErr, err := TestFunctionsCommands(createFunctionsCmd, args)
 	assert.Nil(t, err)
 	if execErr != nil {
-		t.Errorf("create functions error value: %s", execErr.Error())
+		t.Fatal(execErr)
 	}
 	assert.Equal(t, out.String(), "Created test-functions-putstate successfully\n")
 
@@ -105,27 +105,37 @@ func TestStateFunctions(t *testing.T) {
 	}
 
 	outQueryState, _, err := TestFunctionsCommands(querystateFunctionsCmd, queryStateArgs)
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var state utils.FunctionState
 	err = json.Unmarshal(outQueryState.Bytes(), &state)
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Equal(t, "pulsar", state.Key)
 	assert.Equal(t, "hello", state.StringValue)
 	assert.Equal(t, int64(0), state.Version)
 	// put state again
 	outPutStateAgain, _, err := TestFunctionsCommands(putstateFunctionsCmd, putstateArgs)
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.True(t, strings.Contains(outPutStateAgain.String(), "successfully\n"))
 
 	// query state again
 	outQueryStateAgain, _, err := TestFunctionsCommands(querystateFunctionsCmd, queryStateArgs)
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var stateAgain utils.FunctionState
 	err = json.Unmarshal(outQueryStateAgain.Bytes(), &stateAgain)
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Equal(t, int64(1), stateAgain.Version)
 }
@@ -147,20 +157,20 @@ func TestByteValue(t *testing.T) {
 	}
 
 	out, execErr, err := TestFunctionsCommands(createFunctionsCmd, args)
-	assert.Nil(t, err)
-	if execErr != nil {
-		t.Errorf("create functions error value: %s", execErr.Error())
+	if err != nil {
+		t.Fatal(err)
 	}
+	assert.Nil(t, execErr)
 	assert.Equal(t, out.String(), "Created test-functions-putstate-byte-value successfully\n")
 
 	buf := "hello pulsar!"
-	file, err := ioutil.TempFile("", "tmpfile")
+	file, err := ioutil.TempFile("", "byte-value-functions")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	defer os.Remove(file.Name())
 	if _, err := file.Write([]byte(buf)); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	t.Logf("file name:%s", file.Name())
@@ -194,12 +204,16 @@ func TestByteValue(t *testing.T) {
 	}
 
 	outQueryState, _, err := TestFunctionsCommands(querystateFunctionsCmd, queryStateArgs)
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Logf("outQueryState:%s", outQueryState.String())
 
 	var state utils.FunctionState
 	err = json.Unmarshal(outQueryState.Bytes(), &state)
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Equal(t, "pulsar", state.Key)
 	assert.Equal(t, "hello pulsar!", state.StringValue)

--- a/pkg/ctl/sinks/restart_test.go
+++ b/pkg/ctl/sinks/restart_test.go
@@ -18,7 +18,6 @@
 package sinks
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +40,9 @@ func TestRestartSink(t *testing.T) {
 	}
 
 	createOut, _, err := TestSinksCommands(createSinksCmd, args)
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.Equal(t, createOut.String(), "Created test-sink-restart successfully\n")
 
 	restartArgs := []string{"restart",
@@ -50,22 +51,32 @@ func TestRestartSink(t *testing.T) {
 		"--name", "test-sink-restart",
 	}
 
-	_, _, err = TestSinksCommands(restartSinksCmd, restartArgs)
-	assert.Nil(t, err)
-
-	// test failure case
-	failureArgs := []string{"restart",
-		"--name", "not-exist",
+	out, execErr, err := TestSinksCommands(restartSinksCmd, restartArgs)
+	if err != nil {
+		t.Fatal(err)
 	}
-	_, execErr, _ := TestSinksCommands(restartSinksCmd, failureArgs)
-	assert.Equal(t, execErr.Error(), "code: 404 reason: Sink not-exist doesn't exist")
+	assert.Nil(t, execErr)
+	assert.NotEmpty(t, out.String())
 
 	notExistInstanceIDArgs := []string{"restart",
 		"--name", "test-sink-restart",
 		"--instance-id", "12345678",
 	}
-	_, err, _ = TestSinksCommands(restartSinksCmd, notExistInstanceIDArgs)
-	assert.NotNil(t, err)
-	failInstanceIDMsg := "Operation not permitted"
-	assert.True(t, strings.ContainsAny(err.Error(), failInstanceIDMsg))
+	_, execErr, err = TestSinksCommands(restartSinksCmd, notExistInstanceIDArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, execErr)
+}
+
+func TestRestartFailed(t *testing.T) {
+	// test failure case
+	failureArgs := []string{"restart",
+		"--name", "not-exist",
+	}
+	_, execErr, err := TestSinksCommands(restartSinksCmd, failureArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, execErr)
 }

--- a/pkg/ctl/topic/create_test.go
+++ b/pkg/ctl/topic/create_test.go
@@ -39,14 +39,13 @@ func TestCreateNonPersistentTopic(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestCreateTopicAlreadExists(t *testing.T) {
+func TestCreateTopicAlreadyExists(t *testing.T) {
 	args := []string{"create", "test-duplicate-topic", "2"}
 	_, _, _, err := TestTopicCommands(CreateTopicCmd, args)
 	assert.Nil(t, err)
 
 	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
 	assert.NotNil(t, execErr)
-	assert.Equal(t, "code: 409 reason: Partitioned topic already exists", execErr.Error())
 }
 
 func TestCreateTopicArgsError(t *testing.T) {

--- a/pkg/ctl/topic/stats_test.go
+++ b/pkg/ctl/topic/stats_test.go
@@ -112,7 +112,7 @@ func TestGetPartitionedStatsCmd(t *testing.T) {
 }
 
 func TestGetPerPartitionedStatsCmd(t *testing.T) {
-	args := []string{"create", "test-topic-per-partitioned-stats", "2"}
+	args := []string{"create", "test-topic-per-partitioned-stats", "1"}
 	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
 	assert.Nil(t, execErr)
 
@@ -137,9 +137,9 @@ func TestGetPerPartitionedStatsCmd(t *testing.T) {
 		Subscriptions:       map[string]utils.SubscriptionStats{},
 		Replication:         map[string]utils.ReplicatorStats{},
 		DeDuplicationStatus: "",
-		Metadata:            utils.PartitionedTopicMetadata{Partitions: 2},
+		Metadata:            utils.PartitionedTopicMetadata{Partitions: 1},
 		Partitions: map[string]utils.TopicStats{
-			"persistent://public/default/test-topic-per-partitioned-stats": {
+			"persistent://public/default/test-topic-per-partitioned-stats-partition-0": {
 				MsgRateIn:           0,
 				MsgRateOut:          0,
 				MsgThroughputIn:     0,
@@ -149,7 +149,7 @@ func TestGetPerPartitionedStatsCmd(t *testing.T) {
 				Publishers:          []utils.PublisherStats{},
 				Subscriptions:       map[string]utils.SubscriptionStats{},
 				Replication:         map[string]utils.ReplicatorStats{},
-				DeDuplicationStatus: "",
+				DeDuplicationStatus: "Disabled",
 			},
 		},
 	}

--- a/test/script/check.sh
+++ b/test/script/check.sh
@@ -16,10 +16,25 @@ function checkBookieHTTP() {
     done
 }
 
+function checkFunctionWorker() {
+    failed=0
+    until curl localhost:8080/admin/v2/persistent/public/functions/coordinate/stats; do
+        echo "waiting function worker service start..."
+        failed=`expr ${failed} + 1`
+        if [[]]; then
+            echo "function worker service start up was failed"
+            exit 1
+        fi
+        sleep 1
+    done
+}
+
 case $1 in
     bookieHTTP) checkBookieHTTP
     ;;
+    functionWorker) checkFunctionWorker
+    ;;
     *) echo Which service you would like to check?
-       echo Available service: bookieHTTP
+       echo Available service: bookieHTTP, functionWorker
     ;;
 esac


### PR DESCRIPTION
*Motivation*

The function tests are very flaky, so separate the tests to a new CI to avoid rerun all the tests.