### PR TITLE
Fix the TLS not working when enable the oauth2 authentication

### DIFF
--- a/pkg/auth/auth_provider.go
+++ b/pkg/auth/auth_provider.go
@@ -32,6 +32,7 @@ import (
 type Provider interface {
 	RoundTrip(req *http.Request) (*http.Response, error)
 	Transport() http.RoundTripper
+	WithTransport(tripper http.RoundTripper)
 }
 
 type Transport struct {
@@ -40,7 +41,7 @@ type Transport struct {
 
 func GetAuthProvider(config *common.Config) (*Provider, error) {
 	var provider Provider
-	defaultTransport := getDefaultTransport(config)
+	defaultTransport := GetDefaultTransport(config)
 	var err error
 	switch config.AuthPlugin {
 	case TLSPluginName:
@@ -59,13 +60,13 @@ func GetAuthProvider(config *common.Config) (*Provider, error) {
 			provider, err = NewAuthenticationOAuth2WithParams(
 				config.IssuerEndpoint,
 				config.ClientID,
-				config.Audience)
+				config.Audience, defaultTransport)
 		}
 	}
 	return &provider, err
 }
 
-func getDefaultTransport(config *common.Config) http.RoundTripper {
+func GetDefaultTransport(config *common.Config) http.RoundTripper {
 	transport := http.DefaultTransport.(*http.Transport)
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: config.TLSAllowInsecureConnection,

--- a/pkg/auth/oauth2_test.go
+++ b/pkg/auth/oauth2_test.go
@@ -106,7 +106,7 @@ func TestOauth2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	auth, err := NewAuthenticationOauth2(issuer, memoryStore)
+	auth, err := NewAuthenticationOAuth2(issuer, memoryStore)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/auth/tls.go
+++ b/pkg/auth/tls.go
@@ -86,3 +86,8 @@ func (p *TLSAuthProvider) configTLS() error {
 	transport.TLSClientConfig.Certificates = []tls.Certificate{*cert}
 	return nil
 }
+
+func (p *TLSAuthProvider) WithTransport(tripper http.RoundTripper) {
+	p.T = tripper
+}
+

--- a/pkg/auth/tls.go
+++ b/pkg/auth/tls.go
@@ -90,4 +90,3 @@ func (p *TLSAuthProvider) configTLS() error {
 func (p *TLSAuthProvider) WithTransport(tripper http.RoundTripper) {
 	p.T = tripper
 }
-

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -78,3 +78,7 @@ func (p *TokenAuthProvider) RoundTrip(req *http.Request) (*http.Response, error)
 func (p *TokenAuthProvider) Transport() http.RoundTripper {
 	return p.T
 }
+
+func (p *TokenAuthProvider) WithTransport(tripper http.RoundTripper) {
+	p.T = tripper
+}

--- a/pkg/cmdutils/config.go
+++ b/pkg/cmdutils/config.go
@@ -225,7 +225,7 @@ func (c *ClusterConfig) Client(version common.APIVersion) pulsar.Client {
 	config := common.Config(*c)
 	client, err := pulsar.New(&config)
 	if err != nil {
-		log.Fatalf("create pulsar client error: %s", err.Error())
+		fmt.Fprintln(os.Stdout, "Get pulsar client failed: " + err.Error())
 	}
 	return client
 }

--- a/pkg/cmdutils/config.go
+++ b/pkg/cmdutils/config.go
@@ -225,7 +225,7 @@ func (c *ClusterConfig) Client(version common.APIVersion) pulsar.Client {
 	config := common.Config(*c)
 	client, err := pulsar.New(&config)
 	if err != nil {
-		fmt.Fprintln(os.Stdout, "Get pulsar client failed: " + err.Error())
+		fmt.Fprintln(os.Stdout, "Get pulsar client failed: "+err.Error())
 	}
 	return client
 }

--- a/pkg/pulsar/admin.go
+++ b/pkg/pulsar/admin.go
@@ -83,7 +83,10 @@ func New(config *common.Config) (Client, error) {
 	return c, err
 }
 
-func NewWithAuthProvider(config *common.Config, auth auth.Provider) Client {
+func NewWithAuthProvider(config *common.Config, authProvider auth.Provider) Client {
+	defaultTransport := auth.GetDefaultTransport(config)
+	authProvider.WithTransport(defaultTransport)
+
 	c := &pulsarClient{
 		APIVersion: config.PulsarAPIVersion,
 		Client: &cli.Client{
@@ -91,7 +94,7 @@ func NewWithAuthProvider(config *common.Config, auth auth.Provider) Client {
 			VersionInfo: ReleaseVersion,
 			HTTPClient: &http.Client{
 				Timeout:   DefaultHTTPTimeOutDuration,
-				Transport: auth,
+				Transport: authProvider,
 			},
 		},
 	}


### PR DESCRIPTION
---
Fixes #240

*Motivation*

The pulsarctl client has a default TLS config initialize before initiating
the auth provider. We need to make sure the oauth2 provider has the config as well.