### PR TITLE
Fixes default api version to be v2

### DIFF
--- a/pkg/pulsar/common/api_version.go
+++ b/pkg/pulsar/common/api_version.go
@@ -20,7 +20,8 @@ package common
 type APIVersion int
 
 const (
-	V1 APIVersion = iota
+	undefined APIVersion = iota
+	V1
 	V2
 	V3
 )

--- a/pkg/pulsar/common/api_version.go
+++ b/pkg/pulsar/common/api_version.go
@@ -30,6 +30,8 @@ const DefaultAPIVersion = "v2"
 
 func (v APIVersion) String() string {
 	switch v {
+	case undefined:
+		return DefaultAPIVersion
 	case V1:
 		return ""
 	case V2:

--- a/pkg/pulsar/common/api_version_test.go
+++ b/pkg/pulsar/common/api_version_test.go
@@ -27,4 +27,6 @@ func TestApiVersion_String(t *testing.T) {
 	assert.Equal(t, "", V1.String())
 	assert.Equal(t, "v2", V2.String())
 	assert.Equal(t, "v3", V3.String())
+	var undefinedAPIVersion APIVersion
+	assert.Equal(t, "v2", undefinedAPIVersion.String())
 }

--- a/pkg/pulsar/common/api_version_test.go
+++ b/pkg/pulsar/common/api_version_test.go
@@ -28,5 +28,5 @@ func TestApiVersion_String(t *testing.T) {
 	assert.Equal(t, "v2", V2.String())
 	assert.Equal(t, "v3", V3.String())
 	var undefinedAPIVersion APIVersion
-	assert.Equal(t, "v2", undefinedAPIVersion.String())
+	assert.Equal(t, DefaultAPIVersion, undefinedAPIVersion.String())
 }


### PR DESCRIPTION
Fixed #248 
Small fix for default API version
As mentioned in the issue above, if the version is not defined default will now be V1

The `undefined` APIVersion is added in enum as first which will be the default, and then in String() function it will return the default version which is now v2