### PR TITLE
Escape special characters in parts of the URL

### DIFF
--- a/pkg/ctl/subscription/skip_test.go
+++ b/pkg/ctl/subscription/skip_test.go
@@ -84,3 +84,12 @@ func TestSkipNonExistingSub(t *testing.T) {
 	_, execErr, _, _ = TestSubCommands(SkipCmd, args)
 	assert.Equal(t, "code: 404 reason: Subscription not found", execErr.Error())
 }
+
+func TestSkipNoExistingSubCharactersEscaped(t *testing.T) {
+	// If we didn't escape special characters, this would get a "404 reason: Unknown error"
+	// Because the endpoint doesn't exist, not just the subscription doesn't exist
+	args := []string{"skip", "--all", "test-skip-messages-non-existing-sub-topic",
+		"test-skip-messages-non-existing-sub-non-existing/with/special chars"}
+	_, execErr, _, _ := TestSubCommands(SkipCmd, args)
+	assert.Equal(t, "code: 404 reason: Subscription not found", execErr.Error())
+}

--- a/pkg/pulsar/admin.go
+++ b/pkg/pulsar/admin.go
@@ -20,6 +20,7 @@ package pulsar
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"path"
 
 	"github.com/streamnative/pulsarctl/pkg/auth"
@@ -102,5 +103,12 @@ func NewWithAuthProvider(config *common.Config, authProvider auth.Provider) Clie
 }
 
 func (c *pulsarClient) endpoint(componentPath string, parts ...string) string {
-	return path.Join(utils.MakeHTTPPath(c.APIVersion.String(), componentPath), path.Join(parts...))
+	escapedParts := make([]string, len(parts))
+	for i, part := range parts {
+		escapedParts[i] = url.PathEscape(part)
+	}
+	return path.Join(
+		utils.MakeHTTPPath(c.APIVersion.String(), componentPath),
+		path.Join(escapedParts...),
+	)
 }

--- a/pkg/pulsar/admin_test.go
+++ b/pkg/pulsar/admin_test.go
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"testing"
+
+	"github.com/streamnative/pulsarctl/pkg/pulsar/common"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPulsarClientEndpointEscapes(t *testing.T) {
+	client := pulsarClient{Client: nil, APIVersion: common.V2}
+	actual := client.endpoint("/myendpoint", "abc%? /def", "ghi")
+	expected := "/admin/v2/myendpoint/abc%25%3F%20%2Fdef/ghi"
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/pulsar/subscription.go
+++ b/pkg/pulsar/subscription.go
@@ -87,12 +87,12 @@ func (c *pulsarClient) Subscriptions() Subscriptions {
 }
 
 func (s *subscriptions) Create(topic utils.TopicName, sName string, messageID utils.MessageID) error {
-	endpoint := s.pulsar.endpoint(s.basePath, topic.GetRestPath(), s.SubPath, url.QueryEscape(sName))
+	endpoint := s.pulsar.endpoint(s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName))
 	return s.pulsar.Client.Put(endpoint, messageID)
 }
 
 func (s *subscriptions) Delete(topic utils.TopicName, sName string) error {
-	endpoint := s.pulsar.endpoint(s.basePath, topic.GetRestPath(), s.SubPath, url.QueryEscape(sName))
+	endpoint := s.pulsar.endpoint(s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName))
 	return s.pulsar.Client.Delete(endpoint)
 }
 
@@ -103,33 +103,33 @@ func (s *subscriptions) List(topic utils.TopicName) ([]string, error) {
 }
 
 func (s *subscriptions) ResetCursorToMessageID(topic utils.TopicName, sName string, id utils.MessageID) error {
-	endpoint := s.pulsar.endpoint(s.basePath, topic.GetRestPath(), s.SubPath, url.QueryEscape(sName), "resetcursor")
+	endpoint := s.pulsar.endpoint(s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName), "resetcursor")
 	return s.pulsar.Client.Post(endpoint, id)
 }
 
 func (s *subscriptions) ResetCursorToTimestamp(topic utils.TopicName, sName string, timestamp int64) error {
 	endpoint := s.pulsar.endpoint(
-		s.basePath, topic.GetRestPath(), s.SubPath, url.QueryEscape(sName),
+		s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName),
 		"resetcursor", strconv.FormatInt(timestamp, 10))
 	return s.pulsar.Client.Post(endpoint, "")
 }
 
 func (s *subscriptions) ClearBacklog(topic utils.TopicName, sName string) error {
 	endpoint := s.pulsar.endpoint(
-		s.basePath, topic.GetRestPath(), s.SubPath, url.QueryEscape(sName), "skip_all")
+		s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName), "skip_all")
 	return s.pulsar.Client.Post(endpoint, "")
 }
 
 func (s *subscriptions) SkipMessages(topic utils.TopicName, sName string, n int64) error {
 	endpoint := s.pulsar.endpoint(
-		s.basePath, topic.GetRestPath(), s.SubPath, url.QueryEscape(sName),
+		s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName),
 		"skip", strconv.FormatInt(n, 10))
 	return s.pulsar.Client.Post(endpoint, "")
 }
 
 func (s *subscriptions) ExpireMessages(topic utils.TopicName, sName string, expire int64) error {
 	endpoint := s.pulsar.endpoint(
-		s.basePath, topic.GetRestPath(), s.SubPath, url.QueryEscape(sName),
+		s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName),
 		"expireMessages", strconv.FormatInt(expire, 10))
 	return s.pulsar.Client.Post(endpoint, "")
 }
@@ -159,7 +159,7 @@ func (s *subscriptions) PeekMessages(topic utils.TopicName, sName string, n int)
 }
 
 func (s *subscriptions) peekNthMessage(topic utils.TopicName, sName string, pos int) ([]*utils.Message, error) {
-	endpoint := s.pulsar.endpoint(s.basePath, topic.GetRestPath(), "subscription", url.QueryEscape(sName),
+	endpoint := s.pulsar.endpoint(s.basePath, topic.GetRestPath(), "subscription", url.PathEscape(sName),
 		"position", strconv.Itoa(pos))
 
 	resp, err := s.pulsar.Client.MakeRequest(http.MethodGet, endpoint)


### PR DESCRIPTION
Our subscripton name has a slash in it, and "pulsarctl subscriptions seek"
(resetcursor) wasn't working. Looking at our Pulsar Admin HTTP logs and
the pulsar-admin command's source code, it appears they actually URL-encode
all path components (and as a result, the subscription apparently gets
double-encoded). The URL in our logs looked something like:

POST /admin/v2/persistent/mytenant/mynamespace/mytopic/subscription/my%252Fsub/resetcursor/1605911005739

Also, clearly we should be using PathEscape rather than QueryEscape,
since we are using path components. QueryEscape will turn a space into
"+" instead of "%20".

You can also validate that this is the right thing to go by running the
following commands with both pulsarctl and pulsar-admin

pulsarctl functions stats --fqfn "tenant/namespace/foo?bar"
  -> currently in pulsarctl this shows an error
  "Function foo doesn't exist". With this fix, and with pulsar-admin,
  it shows "Function foo?bar doesn't exist"
pulsarctl functions stats --fqfn "tenant/namespace/foo bar"
  -> with this fix pulsarctl shows "Function foo bar doesn't exist",
  which is what pulsar-admin also shows. (If I were to use
  QueryEscape, it would show "Function foo+bar doesn't exist")

See the pulsar-admin code:
pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
* in resetCursorAsync(...): calls Codec.encode which uses URLEncoder to
  encode sub name
* in topicPath: calls WebTarget.addParts(...), which also uses
  URLEncoder to encode each of the parts