### PR TITLE
Clone default transport instead of modifying directly

### DIFF
--- a/.github/workflows/ci-bookie-checks.yml
+++ b/.github/workflows/ci-bookie-checks.yml
@@ -11,10 +11,10 @@ jobs:
   bookie-ut-tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.12
+    - name: Set up Go 1.13
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -11,10 +11,10 @@ jobs:
   function-tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.12
+    - name: Set up Go 1.13
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -47,10 +47,10 @@ jobs:
   sink-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.12
+      - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.13
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -83,10 +83,10 @@ jobs:
   source-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.12
+      - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.13
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-release-checks.yml
+++ b/.github/workflows/ci-release-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.13
         id: go
 
       - name: build

--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -11,10 +11,10 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.12
+      - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.13
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.13
         id: go
 
       - name: Create release directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/streamnative/pulsarctl
 
-go 1.12
+go 1.13
 
 require (
 	github.com/99designs/keyring v1.1.6

--- a/pkg/auth/auth_provider.go
+++ b/pkg/auth/auth_provider.go
@@ -67,7 +67,7 @@ func GetAuthProvider(config *common.Config) (*Provider, error) {
 }
 
 func GetDefaultTransport(config *common.Config) http.RoundTripper {
-	transport := http.DefaultTransport.(*http.Transport)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: config.TLSAllowInsecureConnection,
 	}


### PR DESCRIPTION
## Changes:
auth_provider.go now clones the default (global) transport instead of mutating it directly. Since the returned transport passed to cli client `HTTPClient` and is thus used explicitly I'm thinking this shouldn't be a problem (my rudimentary testing hasn't shown any issues.)

## Motivation:
While pulling functionality from this project (in the pattern of the terraform provider) I've encountered an issue in making requests to arbitrary endpoints with the following error only after configuring a pulsarctl client:
```
 x509: certificate signed by unknown authority
```

## Alternatives:
If we really do need to modify the default (global) transport we could attempt to append to the default SystemSertPool to avoid wiping out all existing certs.
```go
systemPool, err := x509.SystemCertPool()
if err == nil {
	tlsConfig.RootCAs = systemPool
} else {
	tlsConfig.RootCAs = x509.NewCertPool()
}
```