### PR TITLE
Fix the ut ci failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var (
 )
 
 func main() {
+	flag.Parse()
 	rootCmd := pkg.NewPulsarctlCmd()
 	handler := plugin.NewDefaultPluginHandler(plugin.ValidPluginFilenamePrefixes)
 	if printVersion {
@@ -70,5 +71,4 @@ func getArgs() []string {
 
 func init() {
 	flag.BoolVar(&printVersion, "version", false, "print program build version")
-	flag.Parse()
 }


### PR DESCRIPTION
---

*Motivation*

UT CI failed by
```
Usage of /tmp/go-build218884213/b001/pulsarctl.test:
  -version
        print program build version
        FAIL    github.com/streamnative/pulsarctl   0.017s
```