### PR TITLE
Add command topic max unacked messages per subscription. (#246)

### DIFF
--- a/pkg/ctl/topic/get_max_unack_messages_per_subscription.go
+++ b/pkg/ctl/topic/get_max_unack_messages_per_subscription.go
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func GetMaxUnackMessagesPerSubscriptionCmd(vc *cmdutils.VerbCmd) {
+	desc := cmdutils.LongDescription{}
+	desc.CommandUsedFor = "Get max unacked messages per subscription for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	msg := cmdutils.Example{
+		Desc:    "Get max unacked messages per subscription for a topic",
+		Command: "pulsarctl topics get-max-unacked-messages-per-subscription topic",
+	}
+	examples = append(examples, msg)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Get max unacked messages per subscription successfully for [topic]",
+	}
+	out = append(out, successOut, ArgError)
+	out = append(out, TopicNameErrors...)
+	out = append(out, NamespaceErrors...)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"get-max-unacked-messages-per-subscription",
+		"Get max unacked messages per subscription for a topic",
+		desc.ToString(),
+		desc.ExampleToString(),
+		"get-max-unacked-messages-per-subscription",
+	)
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doGetMaxUnackMessagesPerSubscription(vc)
+	}, "the topic name is not specified or the topic name is specified more than one")
+}
+
+func doGetMaxUnackMessagesPerSubscription(vc *cmdutils.VerbCmd) error {
+	// for testing
+	if vc.NameError != nil {
+		return vc.NameError
+	}
+
+	topic, err := utils.GetTopicName(vc.NameArg)
+	if err != nil {
+		return err
+	}
+
+	admin := cmdutils.NewPulsarClient()
+	value, err := admin.Topics().GetMaxUnackMessagesPerSubscription(*topic)
+	if err == nil {
+		vc.Command.Print(value)
+	}
+	return err
+}

--- a/pkg/ctl/topic/max_unack_messages_per_subscription_test.go
+++ b/pkg/ctl/topic/max_unack_messages_per_subscription_test.go
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaxUnackMessagesPerSubscription(t *testing.T) {
+	topicName := "persistent://public/default/test-max-unacked-messages-per-subscription-topic"
+	args := []string{"create", topicName, "1"}
+	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+
+	setArgs := []string{"set-max-unacked-messages-per-subscription", topicName, "-m", "20"}
+	setOut, execErr, _, _ := TestTopicCommands(SetMaxUnackMessagesPerSubscriptionCmd, setArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, setOut.String(), "Set max unacked messages per subscription successfully for ["+topicName+"]\n")
+
+	time.Sleep(time.Duration(1) * time.Second)
+	getArgs := []string{"get-max-unacked-messages-per-subscription", topicName}
+	getOut, execErr, _, _ := TestTopicCommands(GetMaxUnackMessagesPerSubscriptionCmd, getArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, getOut.String(), "20")
+
+	setArgs = []string{"remove-max-unacked-messages-per-subscription", topicName}
+	setOut, execErr, _, _ = TestTopicCommands(RemoveMaxUnackMessagesPerSubscriptionCmd, setArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, setOut.String(), "Remove max unacked messages per subscription successfully for ["+topicName+"]\n")
+
+	time.Sleep(time.Duration(1) * time.Second)
+	getArgs = []string{"get-max-unacked-messages-per-subscription", topicName}
+	getOut, execErr, _, _ = TestTopicCommands(GetMaxUnackMessagesPerSubscriptionCmd, getArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, getOut.String(), "0")
+
+	// test negative value for ttl arg
+	setArgs = []string{"set-max-unacked-messages-per-subscription", topicName, "-m", "-2"}
+	_, execErr, _, _ = TestTopicCommands(SetMaxUnackMessagesPerSubscriptionCmd, setArgs)
+	assert.NotNil(t, execErr)
+	assert.Equal(t, execErr.Error(), "code: 412 reason: maxUnackedNum must be 0 or more")
+}

--- a/pkg/ctl/topic/remove_max_unack_messages_per_subscription.go
+++ b/pkg/ctl/topic/remove_max_unack_messages_per_subscription.go
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func RemoveMaxUnackMessagesPerSubscriptionCmd(vc *cmdutils.VerbCmd) {
+	desc := cmdutils.LongDescription{}
+	desc.CommandUsedFor = "Remove max unacked messages per subscription for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	msg := cmdutils.Example{
+		Desc:    "Remove max unacked messages per subscription for a topic",
+		Command: "pulsarctl topics remove-max-unacked-messages-per-subscription topic",
+	}
+	examples = append(examples, msg)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Remove max unacked messages per subscription successfully for [topic]",
+	}
+	out = append(out, successOut, ArgError)
+	out = append(out, TopicNameErrors...)
+	out = append(out, NamespaceErrors...)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"remove-max-unacked-messages-per-subscription",
+		"Remove max unacked messages per subscription for a topic",
+		desc.ToString(),
+		desc.ExampleToString(),
+		"remove-max-unacked-messages-per-subscription",
+	)
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doRemoveMaxUnackMessagesPerSubscription(vc)
+	}, "the topic name is not specified or the topic name is specified more than one")
+}
+
+func doRemoveMaxUnackMessagesPerSubscription(vc *cmdutils.VerbCmd) error {
+	// for testing
+	if vc.NameError != nil {
+		return vc.NameError
+	}
+
+	topic, err := utils.GetTopicName(vc.NameArg)
+	if err != nil {
+		return err
+	}
+
+	admin := cmdutils.NewPulsarClient()
+	err = admin.Topics().RemoveMaxUnackMessagesPerSubscription(*topic)
+	if err == nil {
+		vc.Command.Printf("Remove max unacked messages per subscription successfully for [%s]\n", topic.String())
+	}
+	return err
+}

--- a/pkg/ctl/topic/set_max_unack_messages_per_subscription.go
+++ b/pkg/ctl/topic/set_max_unack_messages_per_subscription.go
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func SetMaxUnackMessagesPerSubscriptionCmd(vc *cmdutils.VerbCmd) {
+	desc := cmdutils.LongDescription{}
+	desc.CommandUsedFor = "Set max unacked messages per subscription for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	msg := cmdutils.Example{
+		Desc:    "Set max unacked messages per subscription for a topic",
+		Command: "pulsarctl topics set-max-unacked-messages-per-subscription topic -m 10",
+	}
+	examples = append(examples, msg)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Set max unacked messages per subscription successfully for [topic]",
+	}
+	out = append(out, successOut, ArgError)
+	out = append(out, TopicNameErrors...)
+	out = append(out, NamespaceErrors...)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"set-max-unacked-messages-per-subscription",
+		"Set max unacked messages per subscription for a topic",
+		desc.ToString(),
+		desc.ExampleToString(),
+		"set-max-unacked-messages-per-subscription",
+	)
+	var maxUnackedNum int
+	vc.SetRunFuncWithNameArg(func() error {
+		return doSetMaxUnackMessagesPerSubscription(vc, maxUnackedNum)
+	}, "the topic name is not specified or the topic name is specified more than one")
+
+	vc.FlagSetGroup.InFlagSet("MaxUnackedMessagesPerSubscription", func(set *pflag.FlagSet) {
+		set.IntVarP(
+			&maxUnackedNum,
+			"maxNum",
+			"m",
+			0,
+			"Max unacked messages per subscription for a topic")
+	})
+	vc.EnableOutputFlagSet()
+}
+
+func doSetMaxUnackMessagesPerSubscription(vc *cmdutils.VerbCmd, maxUnackedNum int) error {
+	// for testing
+	if vc.NameError != nil {
+		return vc.NameError
+	}
+
+	topic, err := utils.GetTopicName(vc.NameArg)
+	if err != nil {
+		return err
+	}
+	admin := cmdutils.NewPulsarClient()
+	err = admin.Topics().SetMaxUnackMessagesPerSubscription(*topic, maxUnackedNum)
+	if err == nil {
+		vc.Command.Printf("Set max unacked messages per subscription successfully for [%s]\n", topic.String())
+	}
+	return err
+}

--- a/pkg/ctl/topic/topic.go
+++ b/pkg/ctl/topic/topic.go
@@ -62,6 +62,9 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 		GetMaxUnackMessagesPerConsumerCmd,
 		SetMaxUnackMessagesPerConsumerCmd,
 		RemoveMaxUnackMessagesPerConsumerCmd,
+		GetMaxUnackMessagesPerSubscriptionCmd,
+		SetMaxUnackMessagesPerSubscriptionCmd,
+		RemoveMaxUnackMessagesPerSubscriptionCmd,
 	}
 
 	cmdutils.AddVerbCmds(flagGrouping, resourceCmd, commands...)

--- a/pkg/pulsar/topic.go
+++ b/pkg/pulsar/topic.go
@@ -134,6 +134,15 @@ type Topics interface {
 
 	// RemoveMaxUnackMessagesPerConsumer Remove max unacked messages policy on consumer for a topic
 	RemoveMaxUnackMessagesPerConsumer(utils.TopicName) error
+
+	// GetMaxUnackMessagesPerSubscription Get max unacked messages policy on subscription for a topic
+	GetMaxUnackMessagesPerSubscription(utils.TopicName) (int, error)
+
+	// SetMaxUnackMessagesPerSubscription Set max unacked messages policy on subscription for a topic
+	SetMaxUnackMessagesPerSubscription(utils.TopicName, int) error
+
+	// RemoveMaxUnackMessagesPerSubscription Remove max unacked messages policy on subscription for a topic
+	RemoveMaxUnackMessagesPerSubscription(utils.TopicName) error
 }
 
 type topics struct {
@@ -413,5 +422,22 @@ func (t *topics) SetMaxUnackMessagesPerConsumer(topic utils.TopicName, maxUnacke
 
 func (t *topics) RemoveMaxUnackMessagesPerConsumer(topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxUnackedMessagesOnConsumer")
+	return t.pulsar.Client.Delete(endpoint)
+}
+
+func (t *topics) GetMaxUnackMessagesPerSubscription(topic utils.TopicName) (int, error) {
+	var maxNum int
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxUnackedMessagesOnSubscription")
+	err := t.pulsar.Client.Get(endpoint, &maxNum)
+	return maxNum, err
+}
+
+func (t *topics) SetMaxUnackMessagesPerSubscription(topic utils.TopicName, maxUnackedNum int) error {
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxUnackedMessagesOnSubscription")
+	return t.pulsar.Client.Post(endpoint, &maxUnackedNum)
+}
+
+func (t *topics) RemoveMaxUnackMessagesPerSubscription(topic utils.TopicName) error {
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxUnackedMessagesOnSubscription")
 	return t.pulsar.Client.Delete(endpoint)
 }


### PR DESCRIPTION
Add command topic max unacked messages per subscription:

* pulsarctl topics get-max-unacked-messages-per-subscription [topic]
* pulsarctl topics set-max-unacked-messages-per-subscription [topic] -m [max]
* pulsarctl topics remove-max-unacked-messages-per-subscription [topic]