### PR TITLE
Support using Json to configure the token auth provider

### DIFF
--- a/pkg/auth/auth_provider.go
+++ b/pkg/auth/auth_provider.go
@@ -47,6 +47,8 @@ func GetAuthProvider(config *common.Config) (*Provider, error) {
 	case TLSPluginName:
 		provider, err = NewAuthenticationTLSFromAuthParams(config.AuthParams, defaultTransport)
 	case TokenPluginName:
+		fallthrough
+	case TokePluginShortName:
 		provider, err = NewAuthenticationTokenFromAuthParams(config.AuthParams, defaultTransport)
 	default:
 		switch {

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -28,9 +28,9 @@ import (
 )
 
 const (
-	tokenPrefix     = "token:"
-	filePrefix      = "file:"
-	TokenPluginName = "org.apache.pulsar.client.impl.auth.AuthenticationToken"
+	tokenPrefix         = "token:"
+	filePrefix          = "file:"
+	TokenPluginName     = "org.apache.pulsar.client.impl.auth.AuthenticationToken"
 	TokePluginShortName = "token"
 )
 
@@ -66,8 +66,8 @@ func NewAuthenticationTokenFromAuthParams(encodedAuthParam string,
 	var tokenAuthProvider *TokenAuthProvider
 	var err error
 
-	var tokenJson Token
-	err = json.Unmarshal([]byte(encodedAuthParam), &tokenJson)
+	var tokenJSON Token
+	err = json.Unmarshal([]byte(encodedAuthParam), &tokenJSON)
 	if err != nil {
 		switch {
 		case strings.HasPrefix(encodedAuthParam, tokenPrefix):
@@ -78,7 +78,7 @@ func NewAuthenticationTokenFromAuthParams(encodedAuthParam string,
 			tokenAuthProvider, err = NewAuthenticationToken(encodedAuthParam, transport)
 		}
 	} else {
-		tokenAuthProvider, err = NewAuthenticationToken(tokenJson.Token, transport)
+		tokenAuthProvider, err = NewAuthenticationToken(tokenJSON.Token, transport)
 	}
 	return tokenAuthProvider, err
 }

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -32,6 +32,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func TestUseJsonTokenParams(t *testing.T)  {
+	args := []string{"--auth-plugin", "token",
+		"--auth-params", "{\"token\": \"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.Yb52IE0B5wzooAdSlIlskEgb6_HBXST8k3lINZS5wwg\"}",
+		"clusters", "list"}
+	execErr, err := BaseCmd(cluster.ListClustersCmd, args)
+	assert.Nil(t, err)
+	assert.Nil(t, execErr)
+	cmdutils.PulsarCtlConfig = &cmdutils.ClusterConfig{} // Clear the config
+
+	args = []string{
+		"clusters",
+		"list",
+	}
+	execErr, _ = BaseCmd(cluster.ListClustersCmd, args)
+	assert.NotNil(t, execErr)
+	assert.True(t, strings.Contains(execErr.Error(), "401"))
+}
+
 func TestUseToken(t *testing.T) {
 	args := []string{"--token",
 		"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.Yb52IE0B5wzooAdSlIlskEgb6_HBXST8k3lINZS5wwg",


### PR DESCRIPTION
---

*Motivation*

In the pulsar-cient-go, we support using the json format to parse
the auth-params. We'd better to use same way to configure the pulsarctl.