### PR TITLE
Support use short auth name to configure auth

### DIFF
--- a/pkg/auth/auth_provider.go
+++ b/pkg/auth/auth_provider.go
@@ -44,6 +44,8 @@ func GetAuthProvider(config *common.Config) (*Provider, error) {
 	defaultTransport := GetDefaultTransport(config)
 	var err error
 	switch config.AuthPlugin {
+	case TLSPluginShortName:
+		fallthrough
 	case TLSPluginName:
 		provider, err = NewAuthenticationTLSFromAuthParams(config.AuthParams, defaultTransport)
 	case TokenPluginName:

--- a/pkg/auth/tls.go
+++ b/pkg/auth/tls.go
@@ -19,13 +19,20 @@ package auth
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"net/http"
 	"strings"
 )
 
 const (
-	TLSPluginName = "org.apache.pulsar.client.impl.auth.AuthenticationTls"
+	TLSPluginName      = "org.apache.pulsar.client.impl.auth.AuthenticationTls"
+	TLSPluginShortName = "tls"
 )
+
+type TLS struct {
+	TlsCertFile string `json:"tlsCertFile"`
+	TlsKeyFile  string `json:"tlsKeyFile"`
+}
 
 type TLSAuthProvider struct {
 	certificatePath string
@@ -51,16 +58,25 @@ func NewAuthenticationTLSFromAuthParams(encodedAuthParams string,
 	transport http.RoundTripper) (*TLSAuthProvider, error) {
 	var certificatePath string
 	var privateKeyPath string
-	parts := strings.Split(encodedAuthParams, ",")
-	for _, part := range parts {
-		kv := strings.Split(part, ":")
-		switch kv[0] {
-		case "tlsCertFile":
-			certificatePath = kv[1]
-		case "tlsKeyFile":
-			privateKeyPath = kv[1]
+
+	var tlsJSON TLS
+	err := json.Unmarshal([]byte(encodedAuthParams), &tlsJSON)
+	if err != nil {
+		parts := strings.Split(encodedAuthParams, ",")
+		for _, part := range parts {
+			kv := strings.Split(part, ":")
+			switch kv[0] {
+			case "tlsCertFile":
+				certificatePath = kv[1]
+			case "tlsKeyFile":
+				privateKeyPath = kv[1]
+			}
 		}
+	} else {
+		certificatePath = tlsJSON.TlsCertFile
+		privateKeyPath = tlsJSON.TlsKeyFile
 	}
+
 	return NewAuthenticationTLS(certificatePath, privateKeyPath, transport)
 }
 

--- a/pkg/auth/tls.go
+++ b/pkg/auth/tls.go
@@ -30,8 +30,8 @@ const (
 )
 
 type TLS struct {
-	TlsCertFile string `json:"tlsCertFile"`
-	TlsKeyFile  string `json:"tlsKeyFile"`
+	TLSCertFile string `json:"tlsCertFile"`
+	TLSKeyFile  string `json:"tlsKeyFile"`
 }
 
 type TLSAuthProvider struct {
@@ -73,8 +73,8 @@ func NewAuthenticationTLSFromAuthParams(encodedAuthParams string,
 			}
 		}
 	} else {
-		certificatePath = tlsJSON.TlsCertFile
-		privateKeyPath = tlsJSON.TlsKeyFile
+		certificatePath = tlsJSON.TLSCertFile
+		privateKeyPath = tlsJSON.TLSKeyFile
 	}
 
 	return NewAuthenticationTLS(certificatePath, privateKeyPath, transport)

--- a/pkg/ctl/cluster/tls_test.go
+++ b/pkg/ctl/cluster/tls_test.go
@@ -27,6 +27,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTLSWithJsonConfiguration(t *testing.T)  {
+	basePath, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	args := []string{
+		"--auth-plugin", "tls",
+		"--auth-params",
+		"{\"tlsCertFile\":\"" + basePath + "/test/auth/certs/client-cert.pem\"" +
+			",\"tlsKeyFile\":\"" + basePath + "/test/auth/certs/client-key.pem\"}",
+		"clusters", "list",
+	}
+	_, execErr, _ = TestTLSHelp(CreateClusterCmd, args)
+	assert.NotNil(t, execErr)
+}
+
 func TestTLS(t *testing.T) {
 	// There is no tls configuration, the execErr should not nil
 	args := []string{"cluster", "add", "tls"}

--- a/pkg/ctl/cluster/tls_test.go
+++ b/pkg/ctl/cluster/tls_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTLSWithJsonConfiguration(t *testing.T)  {
+func TestTLSWithJsonConfiguration(t *testing.T) {
 	basePath, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err.Error())


### PR DESCRIPTION
---

*Motivation*

Support use `tls` to configure the TLS provider