### PR TITLE
Optimize some operation tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Go Version: go version go1.16.3 darwin/amd64
 
 If you want to enable autocompletion in shell, see [enable_completion](docs/en/enable_completion.md).
 
+## Use contexts
+
+If you want to cache information of multiple clusters, and can switch between multiple clusters, see [How to use pulsarctl context](docs/en/how-to-use-context.md).
+
 ## Project Status
 
 The following is an incomplete list of features that are not yet implemented:

--- a/pkg/cmdutils/config.go
+++ b/pkg/cmdutils/config.go
@@ -189,7 +189,7 @@ func (c *ClusterConfig) Client(version common.APIVersion) pulsar.Client {
 			auth, existAuth := ctxConf.AuthInfos[ctxConf.CurrentContext]
 
 			if !exist || !existAuth {
-				logger.Critical("wrong context:%s\n", ctxConf.CurrentContext)
+				logger.Critical("wrong context:%s\nauth-info and contexts in the pulsarctl configuration file must be specified at the same time\n", ctxConf.CurrentContext)
 				os.Exit(1)
 			}
 			c.WebServiceURL = ctx.BrokerServiceURL

--- a/pkg/ctl/context/create_context.go
+++ b/pkg/ctl/context/create_context.go
@@ -34,7 +34,13 @@ func setContextCmd(vc *cmdutils.VerbCmd) {
 		Desc:    "Sets the user field on the gce context entry without touching other values",
 		Command: "pulsarctl context set [options]",
 	}
-	examples = append(examples, setContext)
+
+	setClusterContext := cmdutils.Example{
+		Desc:    "Use set of context to define your cluster",
+		Command: "pulsarctl context set development --admin-service-url=\"http://1.2.3.4:8080\" --bookie-service-url=\"http://1.2.3.4:8083\"",
+	}
+
+	examples = append(examples, setContext, setClusterContext)
 	desc.CommandExamples = examples
 
 	var out []cmdutils.Output

--- a/pkg/ctl/context/get_contexts.go
+++ b/pkg/ctl/context/get_contexts.go
@@ -18,6 +18,7 @@
 package context
 
 import (
+	"github.com/kris-nova/logger"
 	"github.com/olekukonko/tablewriter"
 	"github.com/streamnative/pulsarctl/pkg/cmdutils"
 	"github.com/streamnative/pulsarctl/pkg/ctl/context/internal"
@@ -95,5 +96,10 @@ func doRunGetContext(vc *cmdutils.VerbCmd, ops *getContextOptions) error {
 	}
 
 	table.Render()
+
+	if len(config.CurrentContext) == 0 {
+		logger.Warning("Check content of pulsarctl config: $HOME/.config/pulsar")
+	}
+
 	return nil
 }


### PR DESCRIPTION
1. Optimize the prompt message that is empty when context get
2. Optimize the lack of auth-info and contexts prompt information in the config file
3. Optimize the context set prompt example
4. Include the "How to use pulsarctl context" guide in the README.md file