### PR TITLE
Add command topic message dispatch rate. (#246)

### DIFF
--- a/pkg/ctl/topic/dispatch_rate_test.go
+++ b/pkg/ctl/topic/dispatch_rate_test.go
@@ -32,7 +32,8 @@ func TestDispatchRate(t *testing.T) {
 	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
 	assert.Nil(t, execErr)
 
-	setArgs := []string{"set-dispatch-rate", topicName, "--msg-dispatch-rate", "5", "--byte-dispatch-rate", "4", "--dispatch-rate-period", "3", "--relative-to-publish-rate"}
+	setArgs := []string{"set-dispatch-rate", topicName, "--msg-dispatch-rate", "5", "--byte-dispatch-rate", "4",
+		"--dispatch-rate-period", "3", "--relative-to-publish-rate"}
 	setOut, execErr, _, _ := TestTopicCommands(SetDispatchRateCmd, setArgs)
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Set message dispatch rate successfully for ["+topicName+"]\n")
@@ -69,7 +70,8 @@ func TestDispatchRate(t *testing.T) {
 	assert.Equal(t, dispatchRateData.RatePeriodInSecond, int64(0))
 	assert.Equal(t, dispatchRateData.RelativeToPublishRate, false)
 
-	setArgs = []string{"set-dispatch-rate", topicName, "--msg-dispatch-rate", "5", "--byte-dispatch-rate", "4", "--dispatch-rate-period", "3"}
+	setArgs = []string{"set-dispatch-rate", topicName, "--msg-dispatch-rate", "5", "--byte-dispatch-rate", "4",
+		"--dispatch-rate-period", "3"}
 	setOut, execErr, _, _ = TestTopicCommands(SetDispatchRateCmd, setArgs)
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Set message dispatch rate successfully for ["+topicName+"]\n")

--- a/pkg/ctl/topic/dispatch_rate_test.go
+++ b/pkg/ctl/topic/dispatch_rate_test.go
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDispatchRate(t *testing.T) {
+	topicName := "persistent://public/default/test-dispatch-rate-topic"
+	args := []string{"create", topicName, "1"}
+	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+
+	setArgs := []string{"set-dispatch-rate", topicName, "--msg-dispatch-rate", "5", "--byte-dispatch-rate", "4", "--dispatch-rate-period", "3", "--relative-to-publish-rate"}
+	setOut, execErr, _, _ := TestTopicCommands(SetDispatchRateCmd, setArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, setOut.String(), "Set message dispatch rate successfully for ["+topicName+"]\n")
+
+	time.Sleep(time.Duration(1) * time.Second)
+	getArgs := []string{"get-dispatch-rate", topicName}
+	getOut, execErr, _, _ := TestTopicCommands(GetDispatchRateCmd, getArgs)
+	var dispatchRateData utils.DispatchRateData
+	err := json.Unmarshal(getOut.Bytes(), &dispatchRateData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Nil(t, execErr)
+	assert.Equal(t, dispatchRateData.DispatchThrottlingRateInMsg, int64(5))
+	assert.Equal(t, dispatchRateData.DispatchThrottlingRateInByte, int64(4))
+	assert.Equal(t, dispatchRateData.RatePeriodInSecond, int64(3))
+	assert.Equal(t, dispatchRateData.RelativeToPublishRate, true)
+
+	setArgs = []string{"remove-dispatch-rate", topicName}
+	setOut, execErr, _, _ = TestTopicCommands(RemoveDispatchRateCmd, setArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, setOut.String(), "Remove message dispatch rate successfully for ["+topicName+"]\n")
+
+	time.Sleep(time.Duration(1) * time.Second)
+	getArgs = []string{"get-dispatch-rate", topicName}
+	getOut, execErr, _, _ = TestTopicCommands(GetDispatchRateCmd, getArgs)
+	err = json.Unmarshal(getOut.Bytes(), &dispatchRateData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Nil(t, execErr)
+	assert.Equal(t, dispatchRateData.DispatchThrottlingRateInMsg, int64(0))
+	assert.Equal(t, dispatchRateData.DispatchThrottlingRateInByte, int64(0))
+	assert.Equal(t, dispatchRateData.RatePeriodInSecond, int64(0))
+	assert.Equal(t, dispatchRateData.RelativeToPublishRate, false)
+
+	setArgs = []string{"set-dispatch-rate", topicName, "--msg-dispatch-rate", "5", "--byte-dispatch-rate", "4", "--dispatch-rate-period", "3"}
+	setOut, execErr, _, _ = TestTopicCommands(SetDispatchRateCmd, setArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, setOut.String(), "Set message dispatch rate successfully for ["+topicName+"]\n")
+
+	time.Sleep(time.Duration(1) * time.Second)
+	getArgs = []string{"get-dispatch-rate", topicName}
+	getOut, execErr, _, _ = TestTopicCommands(GetDispatchRateCmd, getArgs)
+	err = json.Unmarshal(getOut.Bytes(), &dispatchRateData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Nil(t, execErr)
+	assert.Equal(t, dispatchRateData.DispatchThrottlingRateInMsg, int64(5))
+	assert.Equal(t, dispatchRateData.DispatchThrottlingRateInByte, int64(4))
+	assert.Equal(t, dispatchRateData.RatePeriodInSecond, int64(3))
+	assert.Equal(t, dispatchRateData.RelativeToPublishRate, false)
+}

--- a/pkg/ctl/topic/get_dispatch_rate.go
+++ b/pkg/ctl/topic/get_dispatch_rate.go
@@ -1,0 +1,81 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func GetDispatchRateCmd(vc *cmdutils.VerbCmd) {
+	desc := cmdutils.LongDescription{}
+	desc.CommandUsedFor = "Get message dispatch rate for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	msg := cmdutils.Example{
+		Desc:    "Get message dispatch rate for a topic",
+		Command: "pulsarctl topics get-dispatch-rate topic",
+	}
+	examples = append(examples, msg)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Get message dispatch rate successfully for [topic]",
+	}
+	out = append(out, successOut, ArgError)
+	out = append(out, TopicNameErrors...)
+	out = append(out, NamespaceErrors...)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"get-dispatch-rate",
+		"Get message dispatch rate for a topic",
+		desc.ToString(),
+		desc.ExampleToString(),
+		"get-dispatch-rate",
+	)
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doGetDispatchRate(vc)
+	}, "the topic name is not specified or the topic name is specified more than one")
+
+	vc.EnableOutputFlagSet()
+}
+
+func doGetDispatchRate(vc *cmdutils.VerbCmd) error {
+	// for testing
+	if vc.NameError != nil {
+		return vc.NameError
+	}
+
+	topic, err := utils.GetTopicName(vc.NameArg)
+	if err != nil {
+		return err
+	}
+
+	admin := cmdutils.NewPulsarClient()
+	dispatchRateData, err := admin.Topics().GetDispatchRate(*topic)
+	if err == nil {
+		oc := cmdutils.NewOutputContent().WithObject(dispatchRateData)
+		err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
+	}
+	return err
+}

--- a/pkg/ctl/topic/remove_dispatch_rate.go
+++ b/pkg/ctl/topic/remove_dispatch_rate.go
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func RemoveDispatchRateCmd(vc *cmdutils.VerbCmd) {
+	desc := cmdutils.LongDescription{}
+	desc.CommandUsedFor = "Remove message dispatch rate for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	msg := cmdutils.Example{
+		Desc:    "Remove message dispatch rate for a topic",
+		Command: "pulsarctl topics remove-dispatch-rate topic",
+	}
+	examples = append(examples, msg)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Remove message dispatch rate successfully for [topic]",
+	}
+	out = append(out, successOut, ArgError)
+	out = append(out, TopicNameErrors...)
+	out = append(out, NamespaceErrors...)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"remove-dispatch-rate",
+		"Remove message dispatch rate for a topic",
+		desc.ToString(),
+		desc.ExampleToString(),
+		"remove-dispatch-rate",
+	)
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doRemoveDispatchRate(vc)
+	}, "the topic name is not specified or the topic name is specified more than one")
+}
+
+func doRemoveDispatchRate(vc *cmdutils.VerbCmd) error {
+	// for testing
+	if vc.NameError != nil {
+		return vc.NameError
+	}
+
+	topic, err := utils.GetTopicName(vc.NameArg)
+	if err != nil {
+		return err
+	}
+
+	admin := cmdutils.NewPulsarClient()
+	err = admin.Topics().RemoveDispatchRate(*topic)
+	if err == nil {
+		vc.Command.Printf("Remove message dispatch rate successfully for [%s]\n", topic.String())
+	}
+	return err
+}

--- a/pkg/ctl/topic/set_dispatch_rate.go
+++ b/pkg/ctl/topic/set_dispatch_rate.go
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func SetDispatchRateCmd(vc *cmdutils.VerbCmd) {
+	desc := cmdutils.LongDescription{}
+	desc.CommandUsedFor = "Set message dispatch rate for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	msg := cmdutils.Example{
+		Desc: "Set message dispatch rate for a topic",
+		Command: "pulsarctl topics set-dispatch-rate topic " +
+			"--msg-dispatch-rate 4 --byte-dispatch-rate 5 --dispatch-rate-period 6 --relative-to-publish-rate",
+	}
+	examples = append(examples, msg)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Set message dispatch rate successfully for [topic]",
+	}
+	out = append(out, successOut, ArgError)
+	out = append(out, TopicNameErrors...)
+	out = append(out, NamespaceErrors...)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"set-dispatch-rate",
+		"Set message dispatch rate for a topic",
+		desc.ToString(),
+		desc.ExampleToString(),
+		"set-dispatch-rate",
+	)
+	dispatchRateData := &utils.DispatchRateData{}
+	vc.SetRunFuncWithNameArg(func() error {
+		return doSetDispatchRate(vc, dispatchRateData)
+	}, "the topic name is not specified or the topic name is specified more than one")
+
+	vc.FlagSetGroup.InFlagSet("DispatchRate", func(set *pflag.FlagSet) {
+		set.Int64VarP(
+			&dispatchRateData.DispatchThrottlingRateInMsg,
+			"msg-dispatch-rate",
+			"",
+			-1,
+			"message-dispatch-rate (default -1 will be overwrite if not passed)")
+		set.Int64VarP(
+			&dispatchRateData.DispatchThrottlingRateInByte,
+			"byte-dispatch-rate",
+			"",
+			-1,
+			"byte-dispatch-rate (default -1 will be overwrite if not passed)")
+		set.Int64VarP(
+			&dispatchRateData.RatePeriodInSecond,
+			"dispatch-rate-period",
+			"",
+			1,
+			"dispatch-rate-period in second type (default 1 second will be overwrite if not passed)")
+		set.BoolVarP(
+			&dispatchRateData.RelativeToPublishRate,
+			"relative-to-publish-rate",
+			"",
+			false,
+			"dispatch rate relative to publish-rate (if publish-relative flag is enabled "+
+				"then broker will apply throttling value to (publish-rate + dispatch rate))")
+	})
+	vc.EnableOutputFlagSet()
+}
+
+func doSetDispatchRate(vc *cmdutils.VerbCmd, dispatchRateData *utils.DispatchRateData) error {
+	// for testing
+	if vc.NameError != nil {
+		return vc.NameError
+	}
+
+	topic, err := utils.GetTopicName(vc.NameArg)
+	if err != nil {
+		return err
+	}
+	admin := cmdutils.NewPulsarClient()
+	err = admin.Topics().SetDispatchRate(*topic, *dispatchRateData)
+	if err == nil {
+		vc.Command.Printf("Set message dispatch rate successfully for [%s]\n", topic.String())
+	}
+	return err
+}

--- a/pkg/ctl/topic/topic.go
+++ b/pkg/ctl/topic/topic.go
@@ -72,6 +72,9 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 		GetDelayedDeliveryCmd,
 		SetDelayedDeliveryCmd,
 		RemoveDelayedDeliveryCmd,
+		GetDispatchRateCmd,
+		SetDispatchRateCmd,
+		RemoveDispatchRateCmd,
 	}
 
 	cmdutils.AddVerbCmds(flagGrouping, resourceCmd, commands...)

--- a/pkg/pulsar/topic.go
+++ b/pkg/pulsar/topic.go
@@ -161,6 +161,15 @@ type Topics interface {
 
 	// RemoveDelayedDelivery Remove the delayed delivery policy on a topic
 	RemoveDelayedDelivery(utils.TopicName) error
+
+	// GetDispatchRate Get message dispatch rate for a topic
+	GetDispatchRate(utils.TopicName) (*utils.DispatchRateData, error)
+
+	// SetDispatchRate Set message dispatch rate for a topic
+	SetDispatchRate(utils.TopicName, utils.DispatchRateData) error
+
+	// RemoveDispatchRate Remove message dispatch rate for a topic
+	RemoveDispatchRate(utils.TopicName) error
 }
 
 type topics struct {
@@ -491,5 +500,22 @@ func (t *topics) SetDelayedDelivery(topic utils.TopicName, delayedDeliveryData u
 
 func (t *topics) RemoveDelayedDelivery(topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "delayedDelivery")
+	return t.pulsar.Client.Delete(endpoint)
+}
+
+func (t *topics) GetDispatchRate(topic utils.TopicName) (*utils.DispatchRateData, error) {
+	var dispatchRateData utils.DispatchRateData
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "dispatchRate")
+	err := t.pulsar.Client.Get(endpoint, &dispatchRateData)
+	return &dispatchRateData, err
+}
+
+func (t *topics) SetDispatchRate(topic utils.TopicName, dispatchRateData utils.DispatchRateData) error {
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "dispatchRate")
+	return t.pulsar.Client.Post(endpoint, &dispatchRateData)
+}
+
+func (t *topics) RemoveDispatchRate(topic utils.TopicName) error {
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "dispatchRate")
 	return t.pulsar.Client.Delete(endpoint)
 }

--- a/pkg/pulsar/utils/data.go
+++ b/pkg/pulsar/utils/data.go
@@ -381,3 +381,10 @@ type DelayedDeliveryData struct {
 	TickTime float64 `json:"tickTime"`
 	Active   bool    `json:"active"`
 }
+
+type DispatchRateData struct {
+	DispatchThrottlingRateInMsg  int64 `json:"dispatchThrottlingRateInMsg"`
+	DispatchThrottlingRateInByte int64 `json:"dispatchThrottlingRateInByte"`
+	RatePeriodInSecond           int64 `json:"ratePeriodInSecond"`
+	RelativeToPublishRate        bool  `json:"relativeToPublishRate"`
+}


### PR DESCRIPTION
Add command topic Message Dispatch Rate:
> Pulsarctl does not support 2-letter shorthand, so use the full length.

- pulsarctl topics get-dispatch-rate [topic]
- pulsarctl topics set-dispatch-rate [topic] --msg-dispatch-rate 1 --byte-dispatch-rate 2 --dispatch-rate-period 3 --relative-to-publish-rate 
- pulsarctl topics remove-dispatch-rate [topic]