### PR TITLE
Fix the 400 error when create function

### DIFF
--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -7,6 +7,10 @@ on:
       - 'docs/**'
       - 'README.md'
       - 'CONTRIBUTING.md'
+
+env:
+  PULSAR_VERSION: "2.8.0-rc-202106151929"
+
 jobs:
   function-tests:
     runs-on: ubuntu-latest
@@ -28,7 +32,7 @@ jobs:
         docker run -d -it -p 2181:2181 --name pulsar-kafka-zookeeper --network kafka-pulsar wurstmeister/zookeeper
         docker pull wurstmeister/kafka:2.11-1.0.2
         docker run -d -it --network kafka-pulsar -p 6667:6667 -p 9092:9092 -e KAFKA_ADVERTISED_HOST_NAME=pulsar-kafka -e KAFKA_ZOOKEEPER_CONNECT=pulsar-kafka-zookeeper:2181 --name pulsar-kafka wurstmeister/kafka:2.11-1.0.2
-        docker run -d -p 8080:8080 -p 6650:6650 -v ${PWD}:/pulsar_test -v ${PWD}/data:/pulsar/data --name pulsarctl streamnative/pulsar-all:2.7.0.1 bin/pulsar standalone
+        docker run -d -p 8080:8080 -p 6650:6650 -v ${PWD}:/pulsar_test -v ${PWD}/data:/pulsar/data --name pulsarctl streamnative/pulsar-all:${{ env.PULSAR_VERSION }} bin/pulsar standalone
         docker cp pulsar-io-kafka-2.4.0.nar pulsarctl:/pulsar
         docker cp pulsar-io-jdbc-2.4.0.nar pulsarctl:/pulsar
         docker cp pulsarctl:/pulsar/pulsar-io-kafka-2.4.0.nar ${PWD}/test/sources/
@@ -64,7 +68,7 @@ jobs:
           docker run -d -it -p 2181:2181 --name pulsar-kafka-zookeeper --network kafka-pulsar wurstmeister/zookeeper
           docker pull wurstmeister/kafka:2.11-1.0.2
           docker run -d -it --network kafka-pulsar -p 6667:6667 -p 9092:9092 -e KAFKA_ADVERTISED_HOST_NAME=pulsar-kafka -e KAFKA_ZOOKEEPER_CONNECT=pulsar-kafka-zookeeper:2181 --name pulsar-kafka wurstmeister/kafka:2.11-1.0.2
-          docker run -d -p 8080:8080 -p 6650:6650 -v ${PWD}:/pulsar_test -v ${PWD}/data:/pulsar/data --name pulsarctl streamnative/pulsar-all:2.7.0.1 bin/pulsar standalone
+          docker run -d -p 8080:8080 -p 6650:6650 -v ${PWD}:/pulsar_test -v ${PWD}/data:/pulsar/data --name pulsarctl streamnative/pulsar-all:${{ env.PULSAR_VERSION }} bin/pulsar standalone
           docker cp pulsar-io-kafka-2.4.0.nar pulsarctl:/pulsar
           docker cp pulsar-io-jdbc-2.4.0.nar pulsarctl:/pulsar
           docker cp pulsarctl:/pulsar/pulsar-io-kafka-2.4.0.nar ${PWD}/test/sources/
@@ -100,7 +104,7 @@ jobs:
           docker run -d -it -p 2181:2181 --name pulsar-kafka-zookeeper --network kafka-pulsar wurstmeister/zookeeper
           docker pull wurstmeister/kafka:2.11-1.0.2
           docker run -d -it --network kafka-pulsar -p 6667:6667 -p 9092:9092 -e KAFKA_ADVERTISED_HOST_NAME=pulsar-kafka -e KAFKA_ZOOKEEPER_CONNECT=pulsar-kafka-zookeeper:2181 --name pulsar-kafka wurstmeister/kafka:2.11-1.0.2
-          docker run -d -p 8080:8080 -p 6650:6650 -v ${PWD}:/pulsar_test -v ${PWD}/data:/pulsar/data --name pulsarctl streamnative/pulsar-all:2.7.0.1 bin/pulsar standalone
+          docker run -d -p 8080:8080 -p 6650:6650 -v ${PWD}:/pulsar_test -v ${PWD}/data:/pulsar/data --name pulsarctl streamnative/pulsar-all:${{ env.PULSAR_VERSION }} bin/pulsar standalone
           docker cp pulsar-io-kafka-2.4.0.nar pulsarctl:/pulsar
           docker cp pulsar-io-jdbc-2.4.0.nar pulsarctl:/pulsar
           docker cp pulsarctl:/pulsar/pulsar-io-kafka-2.4.0.nar ${PWD}/test/sources/

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -22,32 +22,8 @@ jobs:
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-    - name: Get dependencies
-      run: |
-        wget https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/0.10.2.1/kafka-clients-0.10.2.1.jar
-        wget https://archive.apache.org/dist/pulsar/pulsar-2.4.0/connectors/pulsar-io-kafka-2.4.0.nar
-        wget https://archive.apache.org/dist/pulsar/pulsar-2.4.0/connectors/pulsar-io-jdbc-2.4.0.nar
-        docker network create kafka-pulsar
-        docker pull wurstmeister/zookeeper
-        docker run -d -it -p 2181:2181 --name pulsar-kafka-zookeeper --network kafka-pulsar wurstmeister/zookeeper
-        docker pull wurstmeister/kafka:2.11-1.0.2
-        docker run -d -it --network kafka-pulsar -p 6667:6667 -p 9092:9092 -e KAFKA_ADVERTISED_HOST_NAME=pulsar-kafka -e KAFKA_ZOOKEEPER_CONNECT=pulsar-kafka-zookeeper:2181 --name pulsar-kafka wurstmeister/kafka:2.11-1.0.2
-        docker run -d -p 8080:8080 -p 6650:6650 -v ${PWD}:/pulsar_test -v ${PWD}/data:/pulsar/data --name pulsarctl streamnative/pulsar-all:${{ env.PULSAR_VERSION }} bin/pulsar standalone
-        docker cp pulsar-io-kafka-2.4.0.nar pulsarctl:/pulsar
-        docker cp pulsar-io-jdbc-2.4.0.nar pulsarctl:/pulsar
-        docker cp pulsarctl:/pulsar/pulsar-io-kafka-2.4.0.nar ${PWD}/test/sources/
-        docker cp pulsarctl:/pulsar/pulsar-io-jdbc-2.4.0.nar ${PWD}/test/sinks/
-        docker cp ${PWD}/test/sources/kafkaSourceConfig.yaml pulsarctl:/pulsar/conf
-        docker cp ${PWD}/test/sinks/mysql-jdbc-sink.yaml pulsarctl:/pulsar/conf
-        docker cp kafka-clients-0.10.2.1.jar pulsarctl:/pulsar/lib
-        docker cp pulsarctl:/pulsar/examples/api-examples.jar ${PWD}/test/functions/
-        ls -al test/functions/
-    - name: Waiting for function worker service
-      run: ./test/script/check.sh functionWorker
-    - name: Build
-      run: go build .
     - name: Function tests
-      run: go test -test.timeout 20m -v $(go list ./... | grep functions)
+      run: scripts/run-integration-tests.sh function
   sink-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.dylib
 pulsarctl
 bin/
-api-examples.jar
+test/functions/api-examples.jar
 dummyExample.jar
 pulsar-io-kafka-2.4.0.nar
 kafka-clients-0.10.2.1.jar

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -393,6 +393,7 @@ func responseError(resp *http.Response) error {
 		return e
 	}
 
+	e.Reason = string(body)
 	err = json.Unmarshal(body, &e)
 	if err != nil {
 		e.Reason = string(body)

--- a/pkg/ctl/functions/create_test.go
+++ b/pkg/ctl/functions/create_test.go
@@ -18,112 +18,42 @@
 package functions
 
 import (
-	"os"
+	"path"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/streamnative/pulsarctl/pkg/test"
 )
 
-func TestCreateFunctions(t *testing.T) {
-	basePath, err := getDirHelp()
-	if basePath == "" || err != nil {
-		t.Error(err)
-	}
-
-	jarName := "dummyExample.jar"
-	_, err = os.Create(jarName)
-	assert.Nil(t, err)
-
-	defer os.Remove(jarName)
-
-	goName := "dummyExample.go"
-	_, err = os.Create(goName)
-	assert.Nil(t, err)
-
-	defer os.Remove(goName)
-
-	pyName := "dummyExample.py"
-	_, err = os.Create(pyName)
-	assert.Nil(t, err)
-
-	defer os.Remove(pyName)
-
-	// $ ./pulsarctl functions create
-	// --tenant public
-	// --namespace default
-	// --name test-functions-create
-	// --inputs test-input-topic
-	// --output persistent://public/default/test-output-topic
-	// --classname org.apache.pulsar.functions.api.examples.ExclamationFunction
-	// --jar apache-pulsar-2.4.0/examples/api-examples.jar
-	// --processing-guarantees EFFECTIVELY_ONCE
+func TestCreateJavaFunctions(t *testing.T) {
+	jarName := path.Join(ResourceDir(), "api-examples.jar")
+	fName := "jf" + test.RandomSuffix()
 	args := []string{
 		"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-create",
+		"--name", fName,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
 		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
 		"--jar", jarName,
-		"--processing-guarantees", "EFFECTIVELY_ONCE",
-	}
+		"--processing-guarantees", "EFFECTIVELY_ONCE"}
+	_, execErr, err := TestFunctionsCommands(createFunctionsCmd, args)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
+}
 
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, args)
-	assert.Nil(t, err)
-
-	// $ bin/pulsar-admin functions create
-	// --function-config-file examples/example-function-config.yaml
-	// --jar examples/api-examples.jar
-	argsWithConf := []string{
-		"create",
-		"--function-config-file", basePath + "/test/functions/example-function-config.yaml",
-		"--jar", jarName,
-	}
-
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, argsWithConf)
-	assert.Nil(t, err)
-
-	argsWithFileURL := []string{
-		"create",
-		"--tenant", "public",
-		"--namespace", "default",
-		"--name", "test-functions-create-file",
-		"--inputs", "test-input-topic",
-		"--output", "persistent://public/default/test-output-topic",
-		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
-		"--jar", "file:" + "/pulsar_test/" + jarName,
-		"--processing-guarantees", "EFFECTIVELY_ONCE",
-	}
-
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, argsWithFileURL)
-	assert.Nil(t, err)
-
-	argsWithFileURLGo := []string{
-		"create",
-		"--tenant", "public",
-		"--namespace", "default",
-		"--name", "test-functions-create-file-go",
-		"--inputs", "test-input-topic",
-		"--output", "persistent://public/default/test-output-topic",
-		"--go", "file:" + "/pulsar_test/" + goName,
-		"--processing-guarantees", "EFFECTIVELY_ONCE",
-	}
-
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, argsWithFileURLGo)
-	assert.Nil(t, err)
-
+func TestCreatePyFunction(t *testing.T) {
+	pyName := path.Join(ResourceDir(), "logging_function.py")
+	fName := "function-py" + test.RandomSuffix()
 	argsWithFileURLPy := []string{
 		"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-create-file-py",
+		"--name", fName,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
-		"--py", "file:" + "/pulsar_test/" + pyName,
-		"--processing-guarantees", "EFFECTIVELY_ONCE",
+		"--py", pyName,
+		"--classname", "LoggingFunction",
 	}
-
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, argsWithFileURLPy)
-	assert.Nil(t, err)
+	_, execErr, err := TestFunctionsCommands(createFunctionsCmd, argsWithFileURLPy)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 }

--- a/pkg/ctl/functions/delete_test.go
+++ b/pkg/ctl/functions/delete_test.go
@@ -19,59 +19,64 @@ package functions
 
 import (
 	"os"
+	"path"
 	"strings"
 	"testing"
 
+	"github.com/streamnative/pulsarctl/pkg/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDeleteFunctions(t *testing.T) {
-	jarName := "dummyExample.jar"
-	_, err := os.Create(jarName)
-	assert.Nil(t, err)
+	fName := "df" + test.RandomSuffix()
+	jarName := path.Join(ResourceDir(), "api-examples.jar")
 
-	defer os.Remove(jarName)
 	args := []string{"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-delete",
+		"--name", fName,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
 		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
 		"--jar", jarName,
 	}
 
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, args)
-	assert.Nil(t, err)
+	_, execErr, err := TestFunctionsCommands(createFunctionsCmd, args)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	deleteArgs := []string{"delete",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-delete",
+		"--name", fName,
 	}
 
-	_, _, err = TestFunctionsCommands(deleteFunctionsCmd, deleteArgs)
-	assert.Nil(t, err)
+	_, execErr, err = TestFunctionsCommands(deleteFunctionsCmd, deleteArgs)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
+}
+
+func TestDeleteFunctionsWithFQFN(t *testing.T) {
+	fName := "df" + test.RandomSuffix()
+	jarName := path.Join(ResourceDir(), "api-examples.jar")
 
 	argsFqfn := []string{"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-delete-fqfn",
+		"--name", fName,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
 		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
 		"--jar", jarName,
 	}
 
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, argsFqfn)
-	assert.Nil(t, err)
+	_, execErr, err := TestFunctionsCommands(createFunctionsCmd, argsFqfn)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	deleteArgsFqfn := []string{"delete",
-		"--fqfn", "public/default/test-functions-delete-fqfn",
+		"--fqfn", "public/default/" + fName,
 	}
 
-	_, _, err = TestFunctionsCommands(deleteFunctionsCmd, deleteArgsFqfn)
-	assert.Nil(t, err)
+	_, execErr, err = TestFunctionsCommands(deleteFunctionsCmd, deleteArgsFqfn)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 }
 
 func TestDeleteFunctionsWithFailure(t *testing.T) {

--- a/pkg/ctl/functions/download_test.go
+++ b/pkg/ctl/functions/download_test.go
@@ -19,42 +19,41 @@ package functions
 
 import (
 	"os"
+	"path"
 	"strings"
 	"testing"
 
+	"github.com/streamnative/pulsarctl/pkg/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDownloadFunctions(t *testing.T) {
-	jarName := "dummyExample.jar"
-	_, err := os.Create(jarName)
-	assert.Nil(t, err)
-
-	defer os.Remove(jarName)
+	fName := "df" + test.RandomSuffix()
+	jarName := path.Join(ResourceDir(), "api-examples.jar")
 
 	args := []string{"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-download",
+		"--name", fName,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
 		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
 		"--jar", jarName,
 	}
+	_, execErr, err := TestFunctionsCommands(createFunctionsCmd, args)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, args)
-	assert.Nil(t, err)
-
+	destinationFile := "./dummyExample.jar"
 	downloadArgs := []string{"download",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-download",
-		"--destination-file", "./dummyExample.jar",
+		"--name", fName,
+		"--destination-file", destinationFile,
 	}
 	outPut, execErr, err := TestFunctionsCommands(downloadFunctionsCmd, downloadArgs)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 	assert.Equal(t, outPut.String(), "Downloaded ./dummyExample.jar successfully\n")
-	assert.Nil(t, execErr)
-	assert.Nil(t, err)
+	os.Remove(destinationFile)
 }
 
 func TestDownloadFunctionsWithFailure(t *testing.T) {

--- a/pkg/ctl/functions/get_test.go
+++ b/pkg/ctl/functions/get_test.go
@@ -20,48 +20,46 @@ package functions
 import (
 	"encoding/json"
 	"os"
+	"path"
 	"strings"
 	"testing"
 
 	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+	"github.com/streamnative/pulsarctl/pkg/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetFunction(t *testing.T) {
-	jarName := "dummyExample.jar"
-	_, err := os.Create(jarName)
-	assert.Nil(t, err)
+	fName := "gf" + test.RandomSuffix()
+	jarName := path.Join(ResourceDir(), "api-examples.jar")
 
-	defer os.Remove(jarName)
 	args := []string{"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-get",
+		"--name", fName,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
 		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
 		"--jar", jarName,
 	}
-
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, args)
-	assert.Nil(t, err)
+	_, execErr, err := TestFunctionsCommands(createFunctionsCmd, args)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	getArgs := []string{"get",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-get",
+		"--name", fName,
 	}
-
-	out, _, err := TestFunctionsCommands(getFunctionsCmd, getArgs)
-	assert.Nil(t, err)
+	out, execErr, err := TestFunctionsCommands(getFunctionsCmd, getArgs)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	var functionConfig utils.FunctionConfig
 	err = json.Unmarshal(out.Bytes(), &functionConfig)
-	assert.Nil(t, err)
+	FailImmediatelyIfErrorNotNil(t, err)
 
 	assert.Equal(t, functionConfig.Tenant, "public")
 	assert.Equal(t, functionConfig.Namespace, "default")
-	assert.Equal(t, functionConfig.Name, "test-functions-get")
+	assert.Equal(t, functionConfig.Name, fName)
 	assert.Equal(t, functionConfig.Output, "persistent://public/default/test-output-topic")
 	assert.Equal(t, functionConfig.ClassName, "org.apache.pulsar.functions.api.examples.ExclamationFunction")
 }

--- a/pkg/ctl/functions/list_test.go
+++ b/pkg/ctl/functions/list_test.go
@@ -18,51 +18,48 @@
 package functions
 
 import (
-	"os"
+	"path"
 	"strings"
 	"testing"
 
+	"github.com/streamnative/pulsarctl/pkg/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestListFunctions(t *testing.T) {
-	jarName := "dummyExample.jar"
-	_, err := os.Create(jarName)
-	assert.Nil(t, err)
+	fName := "lf" + test.RandomSuffix()
+	jarName := path.Join(ResourceDir(), "api-examples.jar")
 
-	defer os.Remove(jarName)
 	args := []string{"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-list",
+		"--name", fName,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
 		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
 		"--jar", jarName,
 	}
-
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, args)
-	assert.Nil(t, err)
+	_, execErr, err := TestFunctionsCommands(createFunctionsCmd, args)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	listArgs := []string{"list"}
-	functions, _, err := TestFunctionsCommands(listFunctionsCmd, listArgs)
-	assert.Nil(t, err)
-	assert.True(t, strings.Contains(functions.String(), "test-functions-list"))
+	functions, execErr, err := TestFunctionsCommands(listFunctionsCmd, listArgs)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
+	assert.True(t, strings.Contains(functions.String(), fName))
 
 	deleteArgs := []string{"delete",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-list",
+		"--name", fName,
 	}
-
-	_, _, err = TestFunctionsCommands(deleteFunctionsCmd, deleteArgs)
-	assert.Nil(t, err)
+	_, execErr, err = TestFunctionsCommands(deleteFunctionsCmd, deleteArgs)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	listArgsAgain := []string{"list",
 		"--tenant", "public",
 		"--namespace", "default",
 	}
-	out, _, err := TestFunctionsCommands(listFunctionsCmd, listArgsAgain)
-	assert.Nil(t, err)
+	out, execErr, err := TestFunctionsCommands(listFunctionsCmd, listArgsAgain)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 	assert.False(t, strings.Contains(out.String(), "test-functions-list"))
 }

--- a/pkg/ctl/functions/stop_test.go
+++ b/pkg/ctl/functions/stop_test.go
@@ -19,59 +19,58 @@ package functions
 
 import (
 	"os"
+	"path"
 	"strings"
 	"testing"
 
+	"github.com/streamnative/pulsarctl/pkg/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestStopFunctions(t *testing.T) {
-	jarName := "dummyExample.jar"
-	_, err := os.Create(jarName)
-	assert.Nil(t, err)
+	fName := "stop-f" + test.RandomSuffix()
+	jarName := path.Join(ResourceDir(), "api-examples.jar")
 
-	defer os.Remove(jarName)
 	args := []string{"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-stop",
+		"--name", fName,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
 		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
 		"--jar", jarName,
 	}
 
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, args)
-	assert.Nil(t, err)
+	_, execErr, err := TestFunctionsCommands(createFunctionsCmd, args)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	stopArgs := []string{"stop",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-stop",
+		"--name", fName,
 	}
+	_, execErr, err = TestFunctionsCommands(stopFunctionsCmd, stopArgs)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
-	_, _, err = TestFunctionsCommands(stopFunctionsCmd, stopArgs)
-	assert.Nil(t, err)
-
+	fName = "stop-fafn-f" + test.RandomSuffix()
 	argsFqfn := []string{"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-stop-fqfn",
+		"--name", fName,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
 		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
 		"--jar", jarName,
 	}
 
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, argsFqfn)
-	assert.Nil(t, err)
+	_, execErr, err = TestFunctionsCommands(createFunctionsCmd, argsFqfn)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	stopArgsFqfn := []string{"stop",
-		"--fqfn", "public/default/test-functions-stop-fqfn",
+		"--fqfn", "public/default/" + fName,
 	}
-
-	_, _, err = TestFunctionsCommands(stopFunctionsCmd, stopArgsFqfn)
-	assert.Nil(t, err)
+	_, execErr, err = TestFunctionsCommands(stopFunctionsCmd, stopArgsFqfn)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 }
 
 func TestStopFunctionsWithFailure(t *testing.T) {

--- a/pkg/ctl/functions/test_help.go
+++ b/pkg/ctl/functions/test_help.go
@@ -19,7 +19,9 @@ package functions
 
 import (
 	"bytes"
-	"os"
+	"path"
+	"runtime"
+	"testing"
 
 	"github.com/streamnative/pulsarctl/pkg/cmdutils"
 
@@ -60,30 +62,17 @@ func TestFunctionsCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (
 	return buf, execError, err
 }
 
-var (
-	flag     bool
-	basePath string
-)
+func ResourceDir() string {
+	_, b, _, _ := runtime.Caller(0)
+	d := path.Join(path.Dir(b), "../../../test/functions")
+	return d
+}
 
-func getDirHelp() (string, error) {
-	var err error
-	if !flag {
-		basePath, err = os.Getwd()
-		if err != nil {
-			return "", err
+func FailImmediatelyIfErrorNotNil(t *testing.T, err ...error) {
+	for _, e := range err {
+		if e != nil {
+			t.Logf(e.Error())
+			t.FailNow()
 		}
-
-		err = os.Chdir("../../../")
-		if err != nil {
-			return "", err
-		}
-
-		basePath, err = os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		flag = true
 	}
-
-	return basePath, nil
 }

--- a/pkg/ctl/functions/update_test.go
+++ b/pkg/ctl/functions/update_test.go
@@ -19,50 +19,48 @@ package functions
 
 import (
 	"encoding/json"
-	"os"
+	"path"
 	"strings"
 	"testing"
 
 	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+	"github.com/streamnative/pulsarctl/pkg/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdateFunctions(t *testing.T) {
-	jarName := "dummyExample.jar"
-	_, err := os.Create(jarName)
-	assert.Nil(t, err)
-
-	defer os.Remove(jarName)
+	fName := "function-updates-test" + test.RandomSuffix()
+	jarName := path.Join(ResourceDir(), "api-examples.jar")
 	args := []string{"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-update",
+		"--name", fName,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
 		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
 		"--jar", jarName,
 	}
 
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, args)
-	assert.Nil(t, err)
+	_, execErr, err := TestFunctionsCommands(createFunctionsCmd, args)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	updateArgs := []string{"update",
-		"--name", "test-functions-update",
+		"--name", fName,
 		"--output", "update-output-topic",
 		"--cpu", "5.0",
 	}
 
-	_, _, err = TestFunctionsCommands(updateFunctionsCmd, updateArgs)
-	assert.Nil(t, err)
+	_, execErr, err = TestFunctionsCommands(updateFunctionsCmd, updateArgs)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	getArgs := []string{"get",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-update",
+		"--name", fName,
 	}
 
-	out, _, err := TestFunctionsCommands(getFunctionsCmd, getArgs)
-	assert.Nil(t, err)
+	out, execErr, err := TestFunctionsCommands(getFunctionsCmd, getArgs)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	var functionConfig utils.FunctionConfig
 	err = json.Unmarshal(out.Bytes(), &functionConfig)
@@ -70,29 +68,27 @@ func TestUpdateFunctions(t *testing.T) {
 
 	assert.Equal(t, functionConfig.Tenant, "public")
 	assert.Equal(t, functionConfig.Namespace, "default")
-	assert.Equal(t, functionConfig.Name, "test-functions-update")
+	assert.Equal(t, functionConfig.Name, fName)
 	assert.Equal(t, functionConfig.Output, "update-output-topic")
 	assert.Equal(t, functionConfig.Resources.CPU, 5.0)
 }
 
 func TestUpdateFunctionsFailure(t *testing.T) {
-	jarName := "dummyExample.jar"
-	_, err := os.Create(jarName)
-	assert.Nil(t, err)
+	fname := "function-updates-test-failed" + test.RandomSuffix()
+	jarName := path.Join(ResourceDir(), "api-examples.jar")
 
-	defer os.Remove(jarName)
 	args := []string{"create",
 		"--tenant", "public",
 		"--namespace", "default",
-		"--name", "test-functions-update-failure",
+		"--name", fname,
 		"--inputs", "test-input-topic",
 		"--output", "persistent://public/default/test-output-topic",
 		"--classname", "org.apache.pulsar.functions.api.examples.ExclamationFunction",
 		"--jar", jarName,
 	}
 
-	_, _, err = TestFunctionsCommands(createFunctionsCmd, args)
-	assert.Nil(t, err)
+	_, execErr, err := TestFunctionsCommands(createFunctionsCmd, args)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 
 	// test the function name not exist
 	failureUpdateArgs := []string{"update",
@@ -105,7 +101,7 @@ func TestUpdateFunctionsFailure(t *testing.T) {
 
 	//test no change for update
 	noChangeArgs := []string{"update",
-		"--name", "test-functions-update-failure",
+		"--name", fname,
 		"--output", "persistent://public/default/test-output-topic",
 	}
 

--- a/pkg/ctl/functions/upload_test.go
+++ b/pkg/ctl/functions/upload_test.go
@@ -109,8 +109,7 @@ func TestUploadAndDownloadCommands(t *testing.T) {
 		"--source-file", testFile,
 	}
 	out, execErr, err := TestFunctionsCommands(uploadFunctionsCmd, args)
-	assert.Nil(t, err)
-	assert.Nil(t, execErr)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 	assert.True(t, strings.Contains(out.String(), "successfully"))
 
 	downloadFilePath := "download-upload-file"
@@ -121,8 +120,7 @@ func TestUploadAndDownloadCommands(t *testing.T) {
 	}
 	out, execErr, err = TestFunctionsCommands(downloadFunctionsCmd, args)
 	defer os.RemoveAll(downloadFilePath)
-	assert.Nil(t, err)
-	assert.Nil(t, execErr)
+	FailImmediatelyIfErrorNotNil(t, execErr, err)
 	assert.True(t, strings.Contains(out.String(), "successfully"))
 
 	downloadFileSha, err := getFileSha256(downloadFilePath)

--- a/pkg/ctl/utils/util.go
+++ b/pkg/ctl/utils/util.go
@@ -90,12 +90,8 @@ func InferMissingSinkeArguments(sinkConf *utils.SinkConfig) {
 }
 
 func IsFileExist(filename string) bool {
-	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
-	}
-	fmt.Println("exists", info.Name(), info.Size(), info.ModTime())
-	return true
+	_, err := os.Stat(filename)
+	return !os.IsNotExist(err)
 }
 
 func ValidateSizeString(s string) (int64, error) {

--- a/pkg/pulsar/utils/function_confg.go
+++ b/pkg/pulsar/utils/function_confg.go
@@ -24,54 +24,54 @@ const (
 )
 
 type FunctionConfig struct {
-	TimeoutMs     *int64  `json:"timeoutMs" yaml:"timeoutMs"`
-	TopicsPattern *string `json:"topicsPattern" yaml:"topicsPattern"`
+	TimeoutMs     *int64  `json:"timeoutMs,omitempty" yaml:"timeoutMs"`
+	TopicsPattern *string `json:"topicsPattern,omitempty" yaml:"topicsPattern"`
 	// Whether the subscriptions the functions created/used should be deleted when the functions is deleted
-	CleanupSubscription bool `json:"cleanupSubscription" yaml:"cleanupSubscription"`
-	RetainOrdering      bool `json:"retainOrdering" yaml:"retainOrdering"`
-	AutoAck             bool `json:"autoAck" yaml:"autoAck"`
-	Parallelism         int  `json:"parallelism" yaml:"parallelism"`
-	MaxMessageRetries   *int `json:"maxMessageRetries" yaml:"maxMessageRetries"`
+	CleanupSubscription bool `json:"cleanupSubscription,omitempty" yaml:"cleanupSubscription"`
+	RetainOrdering      bool `json:"retainOrdering,omitempty" yaml:"retainOrdering"`
+	AutoAck             bool `json:"autoAck,omitempty" yaml:"autoAck"`
+	Parallelism         int  `json:"parallelism,omitempty" yaml:"parallelism"`
+	MaxMessageRetries   *int `json:"maxMessageRetries,omitempty" yaml:"maxMessageRetries"`
 
-	Output string `json:"output" yaml:"output"`
+	Output string `json:"output,omitempty" yaml:"output"`
 
-	OutputSerdeClassName string `json:"outputSerdeClassName" yaml:"outputSerdeClassName"`
-	LogTopic             string `json:"logTopic" yaml:"logTopic"`
-	ProcessingGuarantees string `json:"processingGuarantees" yaml:"processingGuarantees"`
+	OutputSerdeClassName string `json:"outputSerdeClassName,omitempty" yaml:"outputSerdeClassName"`
+	LogTopic             string `json:"logTopic,omitempty" yaml:"logTopic"`
+	ProcessingGuarantees string `json:"processingGuarantees,omitempty" yaml:"processingGuarantees"`
 
 	// Represents either a builtin schema type (eg: 'avro', 'json', etc) or the class name for a Schema implementation
-	OutputSchemaType string `json:"outputSchemaType" yaml:"outputSchemaType"`
+	OutputSchemaType string `json:"outputSchemaType,omitempty" yaml:"outputSchemaType"`
 
-	Runtime         string  `json:"runtime" yaml:"runtime"`
-	DeadLetterTopic string  `json:"deadLetterTopic" yaml:"deadLetterTopic"`
-	SubName         string  `json:"subName" yaml:"subName"`
-	FQFN            string  `json:"fqfn" yaml:"fqfn"`
-	Jar             *string `json:"jar" yaml:"jar"`
-	Py              *string `json:"py" yaml:"py"`
-	Go              *string `json:"go" yaml:"go"`
+	Runtime         string  `json:"runtime,omitempty" yaml:"runtime"`
+	DeadLetterTopic string  `json:"deadLetterTopic,omitempty" yaml:"deadLetterTopic"`
+	SubName         string  `json:"subName,omitempty" yaml:"subName"`
+	FQFN            string  `json:"fqfn,omitempty" yaml:"fqfn"`
+	Jar             *string `json:"jar,omitempty" yaml:"jar"`
+	Py              *string `json:"py,omitempty" yaml:"py"`
+	Go              *string `json:"go,omitempty" yaml:"go"`
 	// Any flags that you want to pass to the runtime.
 	// note that in thread mode, these flags will have no impact
-	RuntimeFlags string `json:"runtimeFlags" yaml:"runtimeFlags"`
+	RuntimeFlags string `json:"runtimeFlags,omitempty" yaml:"runtimeFlags"`
 
-	Tenant    string `json:"tenant" yaml:"tenant"`
-	Namespace string `json:"namespace" yaml:"namespace"`
-	Name      string `json:"name" yaml:"name"`
-	ClassName string `json:"className" yaml:"className"`
+	Tenant    string `json:"tenant,omitempty" yaml:"tenant"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace"`
+	Name      string `json:"name,omitempty" yaml:"name"`
+	ClassName string `json:"className,omitempty" yaml:"className"`
 
-	Resources          *Resources             `json:"resources" yaml:"resources"`
-	WindowConfig       *WindowConfig          `json:"windowConfig" yaml:"windowConfig"`
-	Inputs             []string               `json:"inputs" yaml:"inputs"`
-	UserConfig         map[string]interface{} `json:"userConfig" yaml:"userConfig"`
-	CustomSerdeInputs  map[string]string      `json:"customSerdeInputs" yaml:"customSerdeInputs"`
-	CustomSchemaInputs map[string]string      `json:"customSchemaInputs" yaml:"customSchemaInputs"`
+	Resources          *Resources             `json:"resources,omitempty" yaml:"resources"`
+	WindowConfig       *WindowConfig          `json:"windowConfig,omitempty" yaml:"windowConfig"`
+	Inputs             []string               `json:"inputs,omitempty" yaml:"inputs"`
+	UserConfig         map[string]interface{} `json:"userConfig,omitempty" yaml:"userConfig"`
+	CustomSerdeInputs  map[string]string      `json:"customSerdeInputs,omitempty" yaml:"customSerdeInputs"`
+	CustomSchemaInputs map[string]string      `json:"customSchemaInputs,omitempty" yaml:"customSchemaInputs"`
 
 	// A generalized way of specifying inputs
-	InputSpecs map[string]ConsumerConfig `json:"inputSpecs" yaml:"inputSpecs"`
+	InputSpecs map[string]ConsumerConfig `json:"inputSpecs,omitempty" yaml:"inputSpecs"`
 
 	// This is a map of secretName(aka how the secret is going to be
 	// accessed in the function via context) to an object that
 	// encapsulates how the secret is fetched by the underlying
 	// secrets provider. The type of an value here can be found by the
 	// SecretProviderConfigurator.getSecretObjectType() method.
-	Secrets map[string]interface{} `json:"secrets" yaml:"secrets"`
+	Secrets map[string]interface{} `json:"secrets,omitempty" yaml:"secrets"`
 }

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -19,8 +19,8 @@ package test
 
 import (
 	"context"
+	"math/rand"
 	"os/exec"
-	"strconv"
 	"time"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -41,8 +41,18 @@ func NewNetwork(name string) (testcontainers.Network, error) {
 	return net, err
 }
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
 func RandomSuffix() string {
-	return "-" + strconv.FormatInt(time.Now().Unix(), 10)
+	b := make([]rune, 6)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
 }
 
 func ExecCmd(containerID string, cmd []string) (string, error) {

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -5,6 +5,20 @@ set -e
 readonly PULSARCTL_HOME=${PULSARCTL_HOME:-"/pulsarctl"}
 readonly TEST_ARGS=${TEST_ARGS:-""}
 
+function checkFunctionWorker() {
+    failed=0
+    until curl --silent localhost:8080/admin/v2/persistent/public/functions/coordinate/stats; do
+        echo "waiting function worker service start..."
+        failed=`expr ${failed} + 1`
+        if [[ ${failed} == 30 ]]; then
+            echo "function worker service start up was failed"
+            exit 1
+        fi
+        sleep 5
+    done
+    sleep 30
+}
+
 pushd ${PULSARCTL_HOME}
 # startup pulsar service
 scripts/pulsar-service-startup.sh
@@ -17,6 +31,13 @@ case ${TEST_ARGS} in
     tls)
         echo "running tls tests"
         go test -v ./pkg/ctl/cluster -run TestTLS
+        ;;
+    function)
+        echo "running function tests"
+        checkFunctionWorker
+        cp /pulsar/examples/api-examples.jar test/functions/
+        cp /pulsar/examples/python-examples/logging_function.py test/functions/
+        go test -v -test.timeout 5m ./pkg/ctl/functions
         ;;
     *)
         echo "running normal unit tests"

--- a/scripts/pulsar-service-startup.sh
+++ b/scripts/pulsar-service-startup.sh
@@ -6,7 +6,11 @@ readonly PULSAR_HOME=${PULSAR_HOME:-"/pulsar"}
 echo "--- Run pulsar service at the directory ${PULSAR_HOME} ---"
 pushd ${PULSAR_HOME}
 bin/apply-config-from-env.py conf/standalone.conf
-bin/pulsar-daemon start standalone -nss -nfw
+if [ ${FUNCTION_ENABLE} ]; then
+    bin/pulsar-daemon start standalone
+else
+    bin/pulsar-daemon start standalone -nss -nfw
+fi
 until curl http://localhost:8080/admin/v2/tenants > /dev/null 2>&1
 do
     sleep 1

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -12,11 +12,14 @@ docker build --build-arg PULSAR_VERSION=${PULSAR_VERSION} \
 case ${1} in
     token)
         env_file=${PROJECT_ROOT}/test/auth/token.env
-        docker run --env-file ${env_file} -e TEST_ARGS=token ${IMAGE_NAME}
+        docker run --rm --env-file ${env_file} -e TEST_ARGS=token ${IMAGE_NAME}
         ;;
     tls)
         env_file=${PROJECT_ROOT}/test/auth/tls.env
-        docker run --env-file ${env_file} -e TEST_ARGS=tls ${IMAGE_NAME}
+        docker run --rm --env-file ${env_file} -e TEST_ARGS=tls ${IMAGE_NAME}
+        ;;
+    function)
+        docker run --name function --rm -e TEST_ARGS=function -e FUNCTION_ENABLE=true ${IMAGE_NAME}
         ;;
     *)
         env_file=${PROJECT_ROOT}/test/policies/policies.env


### PR DESCRIPTION
---

*Motivation*

When using pulsarctl create functions, pulsarctl always gets 400 bad request
error. That cause by we pass the unneeded field in the request. This PR ignore
the function configurations in the request if the field is empty.

*Modifications*

- Ignore the empty field in the function configuration data when transform to json

*Verify this change*

Update the function test image to running the create function test