### PR TITLE
ci: stop the pulsar service forcefully

### DIFF
--- a/scripts/pulsar-service-shutdown.sh
+++ b/scripts/pulsar-service-shutdown.sh
@@ -4,6 +4,6 @@ set -e
 readonly PULSAR_HOME=${PULSAR_HOME:-"/pulsar"}
 pushd ${PULSAR_HOME}
 echo "--- Stop the pulsar service ---"
-bin/pulsar-daemon stop standalone
+bin/pulsar-daemon stop standalone -force
 echo "--- Pulsar service is stopped ---"
 popd


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Summary

I found that CI always failed, the following is CI log:
```
--- Stop the pulsar service ---
doing stop standalone ...
stopping standalone
Shutdown is in progress... Please wait...
...........
Shutdown is in progress... Please wait...
Thread dumps are taken for analysis at /pulsar/logs/standalone.out
WARNNING :  standalone is not stopped completely.
Error: Process completed with exit code 1.
````
so I add `-force` to `bin/pulsar-daemon stop standalone` for stop the pulsar service forcefully.
