### PR TITLE
Fix the broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,86 +31,89 @@ A CLI tool for the [Apache Pulsar](https://pulsar.incubator.apache.org/) project
 
 | Version | Reference |
 | --------| --------- |
-| [0.5.0](https://github.com/streamnative/pulsarctl/releases/tag/v0.5.0) | [Command Reference](https://streamnative.io/docs/pulsarctl/v0.5.0/) |
-| [0.4.1](https://github.com/streamnative/pulsarctl/releases/tag/v0.4.1) | [Command Reference](https://streamnative.io/docs/pulsarctl/v0.4.1/) |
-| [0.4.0](https://github.com/streamnative/pulsarctl/releases/tag/v0.4.0) | [Command Reference](https://streamnative.io/docs/pulsarctl/v0.4.0/) |
-| [0.3.0](https://github.com/streamnative/pulsarctl/releases/tag/v0.3.0) | [Command Reference](https://streamnative.io/docs/pulsarctl/v0.3.0/) |
-| [0.2.0](https://github.com/streamnative/pulsarctl/releases/tag/v0.2.0) | [Command Reference](https://streamnative.io/docs/pulsarctl/v0.2.0/) |
-| [0.1.0](https://github.com/streamnative/pulsarctl/releases/tag/v0.1.0) | [Command Reference](https://streamnative.io/docs/pulsarctl/v0.1.0/) |
+| [0.5.0](https://github.com/streamnative/pulsarctl/releases/tag/v0.5.0) | [Command Reference](https://docs.streamnative.io/pulsarctl/v0.5.0/) |
+| [0.4.1](https://github.com/streamnative/pulsarctl/releases/tag/v0.4.1) | [Command Reference](https://docs.streamnative.io/pulsarctl/v0.4.1/) |
+| [0.4.0](https://github.com/streamnative/pulsarctl/releases/tag/v0.4.0) | [Command Reference](https://docs.streamnative.io/pulsarctl/v0.4.0/)|
+| [0.3.0](https://github.com/streamnative/pulsarctl/releases/tag/v0.3.0) | [Command Reference](https://docs.streamnative.io/pulsarctl/v0.3.0/) |
+| [0.2.0](https://github.com/streamnative/pulsarctl/releases/tag/v0.2.0) | [Command Reference](https://docs.streamnative.io/pulsarctl/v0.2.0/) |
+| [0.1.0](https://github.com/streamnative/pulsarctl/releases/tag/v0.1.0) | [Command Reference](https://docs.streamnative.io/pulsarctl/v0.1.0/) |
 
-## Install
+## Install pulsarctl
 
-#### Mac
+### Mac operation system
 
-You can install `pulsarctl` using [homebrew](https://brew.sh/) on Mac.
-
+Use [homebrew](https://brew.sh/) to install `pulsarctl` on the Mac operation system.
 
 ```bash
 brew tap streamnative/streamnative
-```
-```bash
 brew install pulsarctl
 ```
 
-#### Linux
+### Linux operation system
+
+Use this command to install `pulsarctl` on the Linux operation system.
 
 ```bash
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/streamnative/pulsarctl/master/install.sh)"
 ```
 
-#### Windows
+### Windows operation system
 
-1. Download the executable from https://github.com/streamnative/pulsarctl/releases. 
-2. Add the pulsarctl directory to your system PATH.
-3. Type `pulsarctl -h` at CMD to test pulsarctl is work.
+To install `pulsarctl` on the Windows operation system, follow these steps:
 
-## Build from code
+1. Download the package from [here](https://github.com/streamnative/pulsarctl/releases). 
+2. Add the `pulsarctl` directory to your system PATH.
+3. Type `pulsarctl -h` at CMD to verify that `pulsarctl` is work.
+
+## Build pulsarctl from codes
 
 ### Prerequisite
 
 - Go 1.11 +
 
-If you have not installed Go, install it according to the [installation instruction](http://golang.org/doc/install).
+  If you have not installed Go, install it according to the [installation instruction](http://golang.org/doc/install).
 
-Since the `go mod` package management tool is used in this project, **Go 1.11 or higher** version is required.
+  Since the `go mod` package management tool is used in this project, **Go 1.11 or higher** version is required.
 
-### Download Code
+### Steps
 
-1. Clone the project from GitHub to your local.
+1. Download codes.
 
-```bash
-git clone https://github.com/streamnative/pulsarctl.git
-```
+   1. Clone the project from GitHub to your local.
 
-2. Use `go mod` to get the dependencies needed for the project.
+      ```bash
+      git clone https://github.com/streamnative/pulsarctl.git
+      ```
 
-```bash
-go mod download
-```
+   2. Use `go mod` to get the dependencies needed for the project.
 
-After entering the `go mod download` command, if some libs can not be downloaded, then you can download them by referring to the proxy provided by [GOPROXY.io](https://goproxy.io/).
+      ```bash
+      go mod download
+      ```
 
-### Build
+      After entering the `go mod download` command, if some libs can not be downloaded, then you can download them by referring to the proxy provided by [GOPROXY.io](https://goproxy.io/).
 
-```bash
-make pulsarctl
-```
+2. Build pulsarctl
 
-If you want to print version of `pulsarctl`, you can use follow commands:
+    ```bash
+    make pulsarctl
+    ```
 
-```
-bin/pulsarctl --version
-```
+    If you want to print version of `pulsarctl`, you can use follow commands:
 
-Output:
+    ```
+    bin/pulsarctl --version
+    ```
 
-```
-Release Version: v2.8.0.3
-Git Commit Hash: add1e586e8d56fcc1cbd2fe94ed75b10d6c54672
-Git Branch: HEAD
-UTC Build Time: 2021-06-26 06:39:16
-Go Version: go version go1.16.3 darwin/amd64
-```
+    **Output**:
+
+    ```
+    Release Version: v2.8.0.3
+    Git Commit Hash: add1e586e8d56fcc1cbd2fe94ed75b10d6c54672
+    Git Branch: HEAD
+    UTC Build Time: 2021-06-26 06:39:16
+    Go Version: go version go1.16.3 darwin/amd64
+    ```
 
 ## Enable Auto-Completion
 
@@ -124,28 +127,34 @@ If you want to cache information of multiple clusters, and can switch between mu
 
 The following is an incomplete list of features that are not yet implemented:
  
-#### Functions
+### Functions
+
 - localrun
 
-#### Sources
-- localrun
-- available-sources
-- reload
+### Sources
 
-#### Sinks
 - localrun
 - available-sources
 - reload
 
-#### Schemas
+### Sinks
+
+- localrun
+- available-sources
+- reload
+
+### Schemas
+
 - extract
 
-#### Namespaces
+### Namespaces
+
 - delete-bookie-affinity-group
 - get-bookie-affinity-group
 - set-bookie-affinity-group 
 
-#### Bookies
+### Bookies
+
 - racks-placement
 - get-bookie-rack
 - delete-bookie-rack
@@ -153,7 +162,7 @@ The following is an incomplete list of features that are not yet implemented:
 
 ## Different With Java Pulsar Admin
 
-We move the subscription commands from the Topics to the Subscriptions in pulsarctl.
+We move the subscription commands from the topics to the subscriptions in pulsarctl.
  
 | pulsar-admin | pulsarctl |
 | ------------ | --------- |


### PR DESCRIPTION
Fix the broken links for pulsarctl command reference and update some grammatical errors.

**Note**
The pulsarctl README will be refined after the `Tools/pulsarctl` is introduced to SN doc website.