### PR TITLE
Support get/remove/set retention policy command for topic

### DIFF
--- a/pkg/ctl/topic/get_retention.go
+++ b/pkg/ctl/topic/get_retention.go
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	util "github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func GetRetentionCmd(vc *cmdutils.VerbCmd) {
+	desc := cmdutils.LongDescription{}
+	desc.CommandUsedFor = "Get the retention policy for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	getRetention := cmdutils.Example{
+		Desc:    "Get the retention policy for a topic",
+		Command: "pulsarctl topics get-retention tenant/namespace/topic",
+	}
+	examples = append(examples, getRetention)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out: "{\n" +
+			"  \"RetentionTimeInMinutes\": 0,\n" +
+			"  \"RetentionSizeInMB\": 0\n" +
+			"}",
+	}
+
+	noTopicName := cmdutils.Output{
+		Desc: "you must specify a tenant/namespace/topic name, please check if the tenant/namespace/topic name is provided",
+		Out:  "[✖]  the topic name is not specified or the topic name is specified more than one",
+	}
+
+	tenantNotExistError := cmdutils.Output{
+		Desc: "the tenant does not exist",
+		Out:  "[✖]  code: 404 reason: Tenant does not exist",
+	}
+
+	nsNotExistError := cmdutils.Output{
+		Desc: "the namespace does not exist",
+		Out:  "[✖]  code: 404 reason: Namespace (tenant/namespace) does not exist",
+	}
+
+	out = append(out, successOut, noTopicName, tenantNotExistError, nsNotExistError)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"get-retention",
+		"Get the retention policy for a topic",
+		desc.ToString(),
+		desc.ExampleToString(),
+		"get-retention",
+	)
+
+	var applied bool
+	vc.FlagSetGroup.InFlagSet("GetR", func(set *pflag.FlagSet) {
+		set.BoolVarP(&applied, "applied", "a", false,
+			"Get the applied policy for the topic")
+	})
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doGetRetention(vc, applied)
+	}, "the topic name is not specified or the topic name is specified more than one")
+}
+
+func doGetRetention(vc *cmdutils.VerbCmd, applied bool) error {
+	topic := vc.NameArg
+	admin := cmdutils.NewPulsarClient()
+	topicName, err := util.GetTopicName(topic)
+	if err != nil {
+		return err
+	}
+
+	policy, err := admin.Topics().GetRetention(*topicName, applied)
+	if err == nil {
+		cmdutils.PrintJSON(vc.Command.OutOrStdout(), &policy)
+	}
+
+	return err
+}

--- a/pkg/ctl/topic/remove_retention.go
+++ b/pkg/ctl/topic/remove_retention.go
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	util "github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func RemoveRetentionCmd(vc *cmdutils.VerbCmd) {
+	desc := cmdutils.LongDescription{}
+	desc.CommandUsedFor = "Remove the retention policy for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	removeRetention := cmdutils.Example{
+		Desc:    "Remove the retention policy for a topic",
+		Command: "pulsarctl topics remove-retention tenant/namespace/topic",
+	}
+	examples = append(examples, removeRetention)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Remove the retention policy for a [topic] successfully",
+	}
+
+	noTopicName := cmdutils.Output{
+		Desc: "you must specify a tenant/namespace/topic name, please check if the tenant/namespace/topic name is provided",
+		Out:  "[✖]  the topic name is not specified or the topic name is specified more than one",
+	}
+
+	tenantNotExistError := cmdutils.Output{
+		Desc: "the tenant does not exist",
+		Out:  "[✖]  code: 404 reason: Tenant does not exist",
+	}
+
+	nsNotExistError := cmdutils.Output{
+		Desc: "the namespace does not exist",
+		Out:  "[✖]  code: 404 reason: Namespace (tenant/namespace) does not exist",
+	}
+
+	out = append(out, successOut, noTopicName, tenantNotExistError, nsNotExistError)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"remove-retention",
+		"Remove the retention policy for a topic",
+		desc.ToString(),
+		desc.ExampleToString(),
+		"remove-retention",
+	)
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doRemoveRetention(vc)
+	}, "the topic name is not specified or the topic name is specified more than one")
+}
+
+func doRemoveRetention(vc *cmdutils.VerbCmd) error {
+	topic := vc.NameArg
+	admin := cmdutils.NewPulsarClient()
+	topicName, err := util.GetTopicName(topic)
+	if err != nil {
+		return err
+	}
+	err = admin.Topics().RemoveRetention(*topicName)
+	if err == nil {
+		vc.Command.Printf("Remove the retention policy for a [%s] successfully\n", topic)
+	}
+	return err
+}

--- a/pkg/ctl/topic/retention_test.go
+++ b/pkg/ctl/topic/retention_test.go
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/streamnative/pulsarctl/pkg/test"
+
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetentionCmd(t *testing.T) {
+	topic := fmt.Sprintf("test-retention-topic-%s", test.RandomSuffix())
+
+	args := []string{"set-retention", topic, "--time", "12h", "--size", "100g"}
+	out, execErr, nameErr, cmdErr := TestTopicCommands(SetRetentionCmd, args)
+	assert.Nil(t, execErr)
+	assert.Nil(t, nameErr)
+	assert.Nil(t, cmdErr)
+	assert.NotNil(t, out)
+	assert.NotEmpty(t, out.String())
+	t.Log(fmt.Sprintf("set-retention response: %s", out.String()))
+
+	// waiting for the pulsar to be configured
+	<-time.After(5 * time.Second)
+
+	args = []string{"get-retention", topic}
+	out, execErr, nameErr, cmdErr = TestTopicCommands(GetRetentionCmd, args)
+	assert.Nil(t, execErr)
+	assert.Nil(t, nameErr)
+	assert.Nil(t, cmdErr)
+	assert.NotNil(t, out)
+	assert.NotEmpty(t, out.String())
+	t.Log(fmt.Sprintf("get-retention response: %s", out.String()))
+
+	var data utils.RetentionPolicies
+	err := json.Unmarshal(out.Bytes(), &data)
+	assert.Nil(t, err)
+	assert.Equal(t, 720, data.RetentionTimeInMinutes)
+	assert.Equal(t, int64(102400), data.RetentionSizeInMB)
+
+	args = []string{"remove-retention", topic}
+	out, execErr, nameErr, cmdErr = TestTopicCommands(RemoveRetentionCmd, args)
+	assert.Nil(t, execErr)
+	assert.Nil(t, nameErr)
+	assert.Nil(t, cmdErr)
+	assert.NotNil(t, out)
+	assert.NotEmpty(t, out.String())
+	t.Log(fmt.Sprintf("remove-retention response: %s", out.String()))
+
+	args = []string{"get-retention", topic}
+	out, execErr, nameErr, cmdErr = TestTopicCommands(GetRetentionCmd, args)
+	assert.Nil(t, execErr)
+	assert.Nil(t, nameErr)
+	assert.Nil(t, cmdErr)
+	assert.NotNil(t, out)
+	assert.NotEmpty(t, out.String())
+	t.Log(fmt.Sprintf("get-retention response: %s", out.String()))
+
+	data = utils.RetentionPolicies{}
+	err = json.Unmarshal(out.Bytes(), &data)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, data.RetentionTimeInMinutes)
+	assert.Equal(t, int64(0), data.RetentionSizeInMB)
+}

--- a/pkg/ctl/topic/set_retention.go
+++ b/pkg/ctl/topic/set_retention.go
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/pkg/errors"
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	ctlutils "github.com/streamnative/pulsarctl/pkg/ctl/utils"
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func SetRetentionCmd(vc *cmdutils.VerbCmd) {
+	desc := cmdutils.LongDescription{}
+	desc.CommandUsedFor = "Set the retention policy for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	removeRetention := cmdutils.Example{
+		Desc:    "Set the retention policy for a topic",
+		Command: "pulsarctl topics set-retention tenant/namespace/topic",
+	}
+	examples = append(examples, removeRetention)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Set the retention policy for [topic] successfully",
+	}
+
+	noTopicName := cmdutils.Output{
+		Desc: "you must specify a tenant/namespace/topic name, please check if the tenant/namespace/topic name is provided",
+		Out:  "[✖]  the topic name is not specified or the topic name is specified more than one",
+	}
+
+	tenantNotExistError := cmdutils.Output{
+		Desc: "the tenant does not exist",
+		Out:  "[✖]  code: 404 reason: Tenant does not exist",
+	}
+
+	nsNotExistError := cmdutils.Output{
+		Desc: "the namespace does not exist",
+		Out:  "[✖]  code: 404 reason: Namespace (tenant/namespace) does not exist",
+	}
+
+	out = append(out, successOut, noTopicName, tenantNotExistError, nsNotExistError)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"set-retention",
+		"Set the retention policy for a topic",
+		desc.ToString(),
+		desc.ExampleToString(),
+		"set-retention",
+	)
+
+	var timeStr string
+	var sizeStr string
+
+	vc.Command.Flags().StringVarP(&timeStr, "time", "", "",
+		"Retention time in minutes (or minutes, hours, days, weeks eg: 100m, 3h, 2d, 5w). "+
+			"0 means no retention and -1 means infinite time retention")
+	vc.Command.Flags().StringVarP(&sizeStr, "size", "", "",
+		"Retention size limit (eg: 10M, 16G, 3T). "+
+			"0 or less than 1MB means no retention and -1 means infinite size retention")
+
+	_ = vc.Command.MarkFlagRequired("time")
+	_ = vc.Command.MarkFlagRequired("size")
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doSetRetention(vc, timeStr, sizeStr)
+	}, "the topic name is not specified or the topic name is specified more than one")
+}
+
+func doSetRetention(vc *cmdutils.VerbCmd, timeStr string, sizeStr string) error {
+	topic := vc.NameArg
+
+	if timeStr == "" {
+		return errors.New("time cannot empty")
+	}
+	if sizeStr == "" {
+		return errors.New("size cannot empty")
+	}
+
+	retentionTimeInSecond, err := ctlutils.ParseRelativeTimeInSeconds(timeStr)
+	if err != nil {
+		return err
+	}
+
+	sizeLimit, err := ctlutils.ValidateSizeString(sizeStr)
+	if err != nil {
+		return err
+	}
+
+	var (
+		retentionTimeInMin int
+		retentionSizeInMB  int
+	)
+
+	if retentionTimeInSecond != -1 {
+		retentionTimeInMin = int(retentionTimeInSecond.Minutes())
+	} else {
+		retentionTimeInMin = -1
+	}
+
+	if sizeLimit != -1 {
+		retentionSizeInMB = int(sizeLimit / (1024 * 1024))
+	} else {
+		retentionSizeInMB = -1
+	}
+
+	admin := cmdutils.NewPulsarClient()
+	topicName, err := utils.GetTopicName(topic)
+	if err != nil {
+		return err
+	}
+
+	err = admin.Topics().SetRetention(*topicName, utils.NewRetentionPolicies(retentionTimeInMin, retentionSizeInMB))
+	if err == nil {
+		vc.Command.Printf("Set the retention policy successfully on [%s]\n", topic)
+	}
+
+	return err
+}

--- a/pkg/ctl/topic/topic.go
+++ b/pkg/ctl/topic/topic.go
@@ -78,6 +78,9 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 		GetDeduplicationStatusCmd,
 		SetDeduplicationStatusCmd,
 		RemoveDeduplicationStatusCmd,
+		GetRetentionCmd,
+		RemoveRetentionCmd,
+		SetRetentionCmd,
 	}
 
 	cmdutils.AddVerbCmds(flagGrouping, resourceCmd, commands...)


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

background from #246,  the PR implements the following commands:

- `pulsar topics get-retention <topic> -a` - Get the retention policy for a topic
- `pulsar topics remove-retention <topic>` - Remove the retention policy for a topic
- `pulsar topics set-retention <topic> --time <string> --size <string>` - Set the retention policy for a topic

