### PR TITLE
feat: add compaction threshold command for topic

### DIFF
--- a/pkg/ctl/topic/compaction_threshold_test.go
+++ b/pkg/ctl/topic/compaction_threshold_test.go
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/streamnative/pulsarctl/pkg/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompactionThresholdCmd(t *testing.T) {
+	topicName := fmt.Sprintf("persistent://public/default/test-compaction-threshold-topic-%s",
+		test.RandomSuffix())
+	createArgs := []string{"create", topicName, "1"}
+	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, createArgs)
+	assert.Nil(t, execErr)
+
+	setArgs := []string{"set-compaction-threshold", topicName, "--threshold", "1G"}
+	out, execErr, _, _ := TestTopicCommands(SetCompactionThresholdCmd, setArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, out.String(),
+		fmt.Sprintf("Successfully set compaction threshold to %d for topic %s", 1024*1024*1024, topicName))
+
+	<-time.After(5 * time.Second)
+
+	getArgs := []string{"get-compaction-threshold", topicName}
+	out, execErr, _, _ = TestTopicCommands(GetCompactionThresholdCmd, getArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, out.String(),
+		fmt.Sprintf("The compaction threshold of the topic %s is %d byte(s)", topicName, 1024*1024*1024))
+
+	removeArgs := []string{"remove-compaction-threshold", topicName}
+	out, execErr, _, _ = TestTopicCommands(RemoveCompactionThresholdCmd, removeArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, out.String(),
+		fmt.Sprintf("Successfully remove compaction threshold for topic %s", topicName))
+
+	<-time.After(5 * time.Second)
+
+	out, execErr, _, _ = TestTopicCommands(GetCompactionThresholdCmd, getArgs)
+	assert.Nil(t, execErr)
+	assert.Equal(t, out.String(),
+		fmt.Sprintf("The compaction threshold of the topic %s is %d byte(s)", topicName, 0))
+}

--- a/pkg/ctl/topic/get_compaction_threshold.go
+++ b/pkg/ctl/topic/get_compaction_threshold.go
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func GetCompactionThresholdCmd(vc *cmdutils.VerbCmd) {
+	var desc cmdutils.LongDescription
+	desc.CommandUsedFor = "Get the compaction threshold for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	set := cmdutils.Example{
+		Desc:    "Get the compaction threshold for a topic",
+		Command: "pulsarctl topics get-compaction-threshold [topic]",
+	}
+	examples = append(examples, set)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "The compaction threshold of the topic (topic-name) is (size) byte(s)",
+	}
+	out = append(out, successOut)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"get-compaction-threshold",
+		desc.CommandUsedFor,
+		desc.ToString(),
+		desc.ExampleToString())
+
+	var applied bool
+	vc.Command.Flags().BoolVarP(&applied, "applied", "", false, "Get the applied policy for the topic")
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doGetCompactionThreshold(vc, applied)
+	}, "the topic name is not specified or the topic name is specified more than one")
+}
+
+func doGetCompactionThreshold(vc *cmdutils.VerbCmd, applied bool) error {
+	topic, err := utils.GetTopicName(vc.NameArg)
+	if err != nil {
+		return err
+	}
+
+	admin := cmdutils.NewPulsarClient()
+	threshold, err := admin.Topics().GetCompactionThreshold(*topic, applied)
+	if err == nil {
+		vc.Command.Printf("The compaction threshold of the topic %s is %d byte(s)", topic, threshold)
+	}
+
+	return err
+}

--- a/pkg/ctl/topic/remove_compaction_threshold.go
+++ b/pkg/ctl/topic/remove_compaction_threshold.go
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+
+	util "github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func RemoveCompactionThresholdCmd(vc *cmdutils.VerbCmd) {
+	var desc cmdutils.LongDescription
+	desc.CommandUsedFor = "Remove the compaction threshold for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	set := cmdutils.Example{
+		Desc:    "Remove the compaction threshold for a topic",
+		Command: "pulsarctl topics remove-compaction-threshold topic",
+	}
+	examples = append(examples, set)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Successfully remove compaction threshold for topic (topic-name)",
+	}
+	out = append(out, successOut)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"remove-compaction-threshold",
+		desc.CommandUsedFor,
+		desc.ToString(),
+		desc.ExampleToString())
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doRemoveCompactionThreshold(vc)
+	}, "the topic name is not specified or the topic name is specified more than one")
+}
+
+func doRemoveCompactionThreshold(vc *cmdutils.VerbCmd) error {
+	topic, err := util.GetTopicName(vc.NameArg)
+	if err != nil {
+		return err
+	}
+
+	admin := cmdutils.NewPulsarClient()
+	err = admin.Topics().RemoveCompactionThreshold(*topic)
+	if err == nil {
+		vc.Command.Printf("Successfully remove compaction threshold for topic %s", topic)
+	}
+
+	return err
+}

--- a/pkg/ctl/topic/set_compaction_threshold.go
+++ b/pkg/ctl/topic/set_compaction_threshold.go
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package topic
+
+import (
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+
+	utils "github.com/streamnative/pulsarctl/pkg/ctl/utils"
+	util "github.com/streamnative/pulsarctl/pkg/pulsar/utils"
+)
+
+func SetCompactionThresholdCmd(vc *cmdutils.VerbCmd) {
+	var desc cmdutils.LongDescription
+	desc.CommandUsedFor = "Set the compaction threshold for a topic"
+	desc.CommandPermission = "This command requires tenant admin permissions."
+
+	var examples []cmdutils.Example
+	set := cmdutils.Example{
+		Desc:    "Set the compaction threshold for a topic",
+		Command: "pulsarctl topics set-compaction-threshold topic --threshold 3T",
+	}
+	examples = append(examples, set)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "normal output",
+		Out:  "Successfully set compaction threshold to (size) for topic (topic-name)",
+	}
+	out = append(out, successOut)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"set-compaction-threshold",
+		desc.CommandUsedFor,
+		desc.ToString(),
+		desc.ExampleToString())
+
+	var threshold string
+	vc.Command.Flags().StringVarP(&threshold, "threshold", "t", "0",
+		"Maximum number of bytes in a topic backlog before compaction is triggered (eg: 10M, 16G, 3T). "+
+			"0 disables automatic compaction")
+	_ = vc.Command.MarkFlagRequired("threshold")
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doSetCompactionThreshold(vc, threshold)
+	}, "the topic name is not specified or the topic name is specified more than one")
+}
+
+func doSetCompactionThreshold(vc *cmdutils.VerbCmd, threshold string) error {
+	topic, err := util.GetTopicName(vc.NameArg)
+	if err != nil {
+		return err
+	}
+
+	size, err := utils.ValidateSizeString(threshold)
+	if err != nil {
+		return err
+	}
+
+	admin := cmdutils.NewPulsarClient()
+	err = admin.Topics().SetCompactionThreshold(*topic, size)
+	if err == nil {
+		vc.Command.Printf("Successfully set compaction threshold to %d for topic %s", size, topic)
+	}
+
+	return err
+}

--- a/pkg/pulsar/topic.go
+++ b/pkg/pulsar/topic.go
@@ -197,6 +197,15 @@ type Topics interface {
 
 	// SetRetention sets the retention policy for a topic
 	SetRetention(utils.TopicName, utils.RetentionPolicies) error
+
+	// Get the compaction threshold for a topic
+	GetCompactionThreshold(topic utils.TopicName, applied bool) (int64, error)
+
+	// Set the compaction threshold for a topic
+	SetCompactionThreshold(topic utils.TopicName, threshold int64) error
+
+	// Remove compaction threshold for a topic
+	RemoveCompactionThreshold(utils.TopicName) error
 }
 
 type topics struct {
@@ -599,4 +608,25 @@ func (t *topics) RemoveRetention(topic utils.TopicName) error {
 func (t *topics) SetRetention(topic utils.TopicName, data utils.RetentionPolicies) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "retention")
 	return t.pulsar.Client.Post(endpoint, data)
+}
+
+func (t *topics) GetCompactionThreshold(topic utils.TopicName, applied bool) (int64, error) {
+	var threshold int64
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "compactionThreshold")
+	_, err := t.pulsar.Client.GetWithQueryParams(endpoint, &threshold, map[string]string{
+		"applied": strconv.FormatBool(applied),
+	}, true)
+	return threshold, err
+}
+
+func (t *topics) SetCompactionThreshold(topic utils.TopicName, threshold int64) error {
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "compactionThreshold")
+	err := t.pulsar.Client.Post(endpoint, threshold)
+	return err
+}
+
+func (t *topics) RemoveCompactionThreshold(topic utils.TopicName) error {
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "compactionThreshold")
+	err := t.pulsar.Client.Delete(endpoint)
+	return err
 }


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Changes

background from #246,  the PR implements the following commands:

- `pulsarctl topics get-compaction-threshold <topic> --applied <bool>` - Get the compaction threshold for a topic
- `pulsarctl topics remove-compaction-threshold <topic>` - Remove the compaction threshold for a topic
- `pulsarctl topics set-compaction-threshold <topic> --threshold <string>` Set the compaction threshold for a topic
