### PR TITLE
Refactor the structure of release scripts to facilitate CI management

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Releasing pulsarctl"
+
+version=${1#v}
+if [[ "x$version" == "x" ]]; then
+  echo "You need give a version number of the pulsarctl"
+  exit 1
+fi
+
+# Create a direcotry to save assets
+ASSETSDIR=release
+mkdir $ASSETSDIR
+
+function build_amd64_linux() {
+  DIR=pulsarctl-amd64-linux
+  mkdir ${DIR}
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o pulsarctl -ldflags "-X github.com/streamnative/pulsarctl/pkg/pulsar.ReleaseVersion=Pulsarctl-Go-$version" .
+  mv pulsarctl ${DIR}
+  cp -r plugins ${DIR}
+  tar -czf ${DIR}.tar.gz ${DIR}
+  mv ${DIR}.tar.gz $ASSETSDIR
+}
+
+function build_386_linux() {
+  DIR=pulsarctl-386-linux
+  mkdir ${DIR}
+  CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -o pulsarctl -ldflags "-X github.com/streamnative/pulsarctl/pkg/pulsar.ReleaseVersion=Pulsarctl-Go-$version" .
+  mv pulsarctl ${DIR}
+  cp -r plugins ${DIR}
+  tar -czf ${DIR}.tar.gz ${DIR}
+  mv ${DIR}.tar.gz $ASSETSDIR
+}
+
+function build_amd64_darwin() {
+  DIR=pulsarctl-amd64-darwin
+  mkdir ${DIR}
+  CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o pulsarctl -ldflags "-X github.com/streamnative/pulsarctl/pkg/pulsar.ReleaseVersion=Pulsarctl-Go-$version" .
+  mv pulsarctl ${DIR}
+  cp -r plugins ${DIR}
+  tar -czf ${DIR}.tar.gz ${DIR}
+  mv ${DIR}.tar.gz $ASSETSDIR
+}
+
+function build_arm64_darwin() {
+  DIR=pulsarctl-arm64-darwin
+  mkdir ${DIR}
+  CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o pulsarctl -ldflags "-X github.com/streamnative/pulsarctl/pkg/pulsar.ReleaseVersion=Pulsarctl-Go-$version" .
+  mv pulsarctl ${DIR}
+  cp -r plugins ${DIR}
+  tar -czf ${DIR}.tar.gz ${DIR}
+  mv ${DIR}.tar.gz $ASSETSDIR
+}
+
+function build_386_darwin() {
+  DIR=pulsarctl-386-darwin
+  mkdir ${DIR}
+  CGO_ENABLED=0 GOOS=darwin GOARCH=386 go build -o pulsarctl -ldflags "-X github.com/streamnative/pulsarctl/pkg/pulsar.ReleaseVersion=Pulsarctl-Go-$version" .
+  mv pulsarctl ${DIR}
+  cp -r plugins ${DIR}
+  tar -czf ${DIR}.tar.gz ${DIR}
+  mv ${DIR}.tar.gz $ASSETSDIR
+}
+
+function build_amd64_windows() {
+  DIR=pulsarctl-amd64-windows
+  mkdir ${DIR}
+  CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o  pulsarctl.exe -ldflags "-X github.com/streamnative/pulsarctl/pkg/pulsar.ReleaseVersion=Pulsarctl-Go-$version" .
+  mv pulsarctl.exe ${DIR}
+  cp -r plugins ${DIR}
+  tar -czf ${DIR}.tar.gz ${DIR}
+  mv ${DIR}.tar.gz $ASSETSDIR
+}
+
+function build_386_windows() {
+  DIR=pulsarctl-386-windows
+  mkdir ${DIR}
+  CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -o  pulsarctl.exe -ldflags "-X github.com/streamnative/pulsarctl/pkg/pulsar.ReleaseVersion=Pulsarctl-Go-$version" .
+  mv pulsarctl.exe ${DIR}
+  cp -r plugins ${DIR}
+  tar -czf ${DIR}.tar.gz ${DIR}
+  mv ${DIR}.tar.gz $ASSETSDIR
+}
+
+function build_doc() {
+  echo ${version} > VERSION
+  make cli
+  mv pulsarctl-site-${version}.tar.gz ${ASSETSDIR}
+}
+
+build_amd64_linux
+build_386_linux
+build_amd64_darwin
+build_arm64_darwin
+build_amd64_windows
+build_386_windows
+build_doc

--- a/scripts/dev/__init__.py
+++ b/scripts/dev/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+#     specific language governing permissions and limitations
+# under the License.
+#

--- a/scripts/dev/set-project-version.py
+++ b/scripts/dev/set-project-version.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+#     specific language governing permissions and limitations
+# under the License.
+
+#!/usr/bin/env python3
+
+import fileinput
+import glob
+import sys
+
+version = sys.argv[1]
+
+filename = glob.glob('./scripts/run-integration-tests.sh', recursive=True)[0]
+
+oldline = 'readonly PULSAR_DEFAULT_VERSION='
+newline = '{}"{}"'.format(oldline, version)
+process = lambda l : newline + '\n' if l.count(oldline) else l
+
+lines = fileinput.input(files=(filename), inplace=True)
+
+for line in lines:
+    print(process(line), end='')


### PR DESCRIPTION
### Motivation

In order to facilitate the management of the release process, we need to strictly standardize the naming of scripts and the structure of related directories 

### Changes

We changed the structure of related scripts and directories.

### Documentation

Not needed