### PR TITLE
feat(topics): optimize the example and error msg in set-retention

### DIFF
--- a/golangci.yml
+++ b/golangci.yml
@@ -1,10 +1,6 @@
 run:
   deadline: 6m
 
-linters-settings:
-  lll:
-    line-length: 150
-
 linters:
   disable-all: true
   enable:

--- a/golangci.yml
+++ b/golangci.yml
@@ -1,6 +1,10 @@
 run:
   deadline: 6m
 
+linters-settings:
+  lll:
+    line-length: 150
+
 linters:
   disable-all: true
   enable:

--- a/pkg/ctl/topic/errors_topic.go
+++ b/pkg/ctl/topic/errors_topic.go
@@ -56,7 +56,7 @@ var InvalidPartitionsNumberError = cmdutils.Output{
 
 var TopicLevelPolicyNotEnabledError = cmdutils.Output{
 	Desc: "topic-level policy is not enabled",
-	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable configs of systemTopicEnabled and topicLevelPoliciesEnabled in brokers",
+	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, set configs of systemTopicEnabled and topicLevelPoliciesEnabled in brokers",
 }
 
 var TopicNameErrors = []cmdutils.Output{

--- a/pkg/ctl/topic/errors_topic.go
+++ b/pkg/ctl/topic/errors_topic.go
@@ -56,7 +56,7 @@ var InvalidPartitionsNumberError = cmdutils.Output{
 
 var TopicLevelPolicyNotEnabledError = cmdutils.Output{
 	Desc: "topic-level policy is not enabled",
-	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable the topic level policy in Brokers by config of systemTopicEnabled and topicLevelPoliciesEnabled",
+	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable the topic level policy in brokers by configs of systemTopicEnabled and topicLevelPoliciesEnabled",
 }
 
 var TopicNameErrors = []cmdutils.Output{

--- a/pkg/ctl/topic/errors_topic.go
+++ b/pkg/ctl/topic/errors_topic.go
@@ -56,7 +56,7 @@ var InvalidPartitionsNumberError = cmdutils.Output{
 
 var TopicLevelPolicyNotEnabledError = cmdutils.Output{
 	Desc: "topic-level policy is not enabled",
-	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, set configs of systemTopicEnabled and topicLevelPoliciesEnabled in brokers",
+	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable broker configs of systemTopicEnabled and topicLevelPoliciesEnabled",
 }
 
 var TopicNameErrors = []cmdutils.Output{

--- a/pkg/ctl/topic/errors_topic.go
+++ b/pkg/ctl/topic/errors_topic.go
@@ -56,7 +56,8 @@ var InvalidPartitionsNumberError = cmdutils.Output{
 
 var TopicLevelPolicyNotEnabledError = cmdutils.Output{
 	Desc: "topic-level policy is not enabled",
-	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable broker configs of systemTopicEnabled and topicLevelPoliciesEnabled",
+	Out: "[✖]  code: 405 reason: Topic level policy is disabled, " +
+		"please enable broker configs of systemTopicEnabled and topicLevelPoliciesEnabled",
 }
 
 var TopicNameErrors = []cmdutils.Output{

--- a/pkg/ctl/topic/errors_topic.go
+++ b/pkg/ctl/topic/errors_topic.go
@@ -56,7 +56,7 @@ var InvalidPartitionsNumberError = cmdutils.Output{
 
 var TopicLevelPolicyNotEnabledError = cmdutils.Output{
 	Desc: "topic-level policy is not enabled",
-	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable the topic level policy and retry",
+	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable the topic level policy in Brokers by config of systemTopicEnabled and topicLevelPoliciesEnabled",
 }
 
 var TopicNameErrors = []cmdutils.Output{

--- a/pkg/ctl/topic/errors_topic.go
+++ b/pkg/ctl/topic/errors_topic.go
@@ -56,7 +56,7 @@ var InvalidPartitionsNumberError = cmdutils.Output{
 
 var TopicLevelPolicyNotEnabledError = cmdutils.Output{
 	Desc: "topic-level policy is not enabled",
-	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable the topic level policy in brokers by configs of systemTopicEnabled and topicLevelPoliciesEnabled",
+	Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable configs of systemTopicEnabled and topicLevelPoliciesEnabled in brokers",
 }
 
 var TopicNameErrors = []cmdutils.Output{

--- a/pkg/ctl/topic/set_retention.go
+++ b/pkg/ctl/topic/set_retention.go
@@ -27,7 +27,7 @@ import (
 func SetRetentionCmd(vc *cmdutils.VerbCmd) {
 	desc := cmdutils.LongDescription{}
 	desc.CommandUsedFor = "Set the retention policy for a topic"
-	desc.CommandPermission = "This command requires tenant admin permissions and topic-level policy should be enabled in Brokers"
+	desc.CommandPermission = "This command requires tenant admin permissions and topic-level policy should be enabled in brokers"
 
 	var examples []cmdutils.Example
 	removeRetention := cmdutils.Example{
@@ -60,7 +60,7 @@ func SetRetentionCmd(vc *cmdutils.VerbCmd) {
 
 	topicLevelPolicyNotEnabledError := cmdutils.Output{
 		Desc: "topic-level policy is not enabled",
-		Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable the topic level policy in Brokers by config of systemTopicEnabled and topicLevelPoliciesEnabled",
+		Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable the topic level policy in brokers by configs of systemTopicEnabled and topicLevelPoliciesEnabled",
 	}
 
 	out = append(out, successOut, noTopicName, tenantNotExistError, nsNotExistError, topicLevelPolicyNotEnabledError)

--- a/pkg/ctl/topic/set_retention.go
+++ b/pkg/ctl/topic/set_retention.go
@@ -27,12 +27,12 @@ import (
 func SetRetentionCmd(vc *cmdutils.VerbCmd) {
 	desc := cmdutils.LongDescription{}
 	desc.CommandUsedFor = "Set the retention policy for a topic"
-	desc.CommandPermission = "This command requires tenant admin permissions."
+	desc.CommandPermission = "This command requires tenant admin permissions and topic-level policy should be enabled in Brokers"
 
 	var examples []cmdutils.Example
 	removeRetention := cmdutils.Example{
 		Desc:    "Set the retention policy for a topic",
-		Command: "pulsarctl topics set-retention tenant/namespace/topic",
+		Command: "pulsarctl topics set-retention tenant/namespace/topic --time 100m --size 1G",
 	}
 	examples = append(examples, removeRetention)
 	desc.CommandExamples = examples
@@ -58,7 +58,12 @@ func SetRetentionCmd(vc *cmdutils.VerbCmd) {
 		Out:  "[✖]  code: 404 reason: Namespace (tenant/namespace) does not exist",
 	}
 
-	out = append(out, successOut, noTopicName, tenantNotExistError, nsNotExistError)
+	topicLevelPolicyNotEnabledError := cmdutils.Output{
+		Desc: "topic-level policy is not enabled",
+		Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable the topic level policy in Brokers by config of systemTopicEnabled and topicLevelPoliciesEnabled",
+	}
+
+	out = append(out, successOut, noTopicName, tenantNotExistError, nsNotExistError, topicLevelPolicyNotEnabledError)
 	desc.CommandOutput = out
 
 	vc.SetDescription(

--- a/pkg/ctl/topic/set_retention.go
+++ b/pkg/ctl/topic/set_retention.go
@@ -60,7 +60,7 @@ func SetRetentionCmd(vc *cmdutils.VerbCmd) {
 
 	topicLevelPolicyNotEnabledError := cmdutils.Output{
 		Desc: "topic-level policy is not enabled",
-		Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable the topic level policy in brokers by configs of systemTopicEnabled and topicLevelPoliciesEnabled",
+		Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable configs of systemTopicEnabled and topicLevelPoliciesEnabled in brokers",
 	}
 
 	out = append(out, successOut, noTopicName, tenantNotExistError, nsNotExistError, topicLevelPolicyNotEnabledError)

--- a/pkg/ctl/topic/set_retention.go
+++ b/pkg/ctl/topic/set_retention.go
@@ -27,7 +27,7 @@ import (
 func SetRetentionCmd(vc *cmdutils.VerbCmd) {
 	desc := cmdutils.LongDescription{}
 	desc.CommandUsedFor = "Set the retention policy for a topic"
-	desc.CommandPermission = "This command requires tenant admin permissions and topic-level policy should be enabled in brokers"
+	desc.CommandPermission = "This command requires tenant admin permissions"
 
 	var examples []cmdutils.Example
 	removeRetention := cmdutils.Example{

--- a/pkg/ctl/topic/set_retention.go
+++ b/pkg/ctl/topic/set_retention.go
@@ -60,7 +60,7 @@ func SetRetentionCmd(vc *cmdutils.VerbCmd) {
 
 	topicLevelPolicyNotEnabledError := cmdutils.Output{
 		Desc: "topic-level policy is not enabled",
-		Out:  "[✖]  code: 405 reason: Topic level policy is disabled, set configs of systemTopicEnabled and topicLevelPoliciesEnabled in brokers",
+		Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable broker configs of systemTopicEnabled and topicLevelPoliciesEnabled",
 	}
 
 	out = append(out, successOut, noTopicName, tenantNotExistError, nsNotExistError, topicLevelPolicyNotEnabledError)

--- a/pkg/ctl/topic/set_retention.go
+++ b/pkg/ctl/topic/set_retention.go
@@ -60,7 +60,7 @@ func SetRetentionCmd(vc *cmdutils.VerbCmd) {
 
 	topicLevelPolicyNotEnabledError := cmdutils.Output{
 		Desc: "topic-level policy is not enabled",
-		Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable configs of systemTopicEnabled and topicLevelPoliciesEnabled in brokers",
+		Out:  "[✖]  code: 405 reason: Topic level policy is disabled, set configs of systemTopicEnabled and topicLevelPoliciesEnabled in brokers",
 	}
 
 	out = append(out, successOut, noTopicName, tenantNotExistError, nsNotExistError, topicLevelPolicyNotEnabledError)

--- a/pkg/ctl/topic/set_retention.go
+++ b/pkg/ctl/topic/set_retention.go
@@ -27,7 +27,7 @@ import (
 func SetRetentionCmd(vc *cmdutils.VerbCmd) {
 	desc := cmdutils.LongDescription{}
 	desc.CommandUsedFor = "Set the retention policy for a topic"
-	desc.CommandPermission = "This command requires tenant admin permissions"
+	desc.CommandPermission = "This command requires tenant admin permissions."
 
 	var examples []cmdutils.Example
 	removeRetention := cmdutils.Example{

--- a/pkg/ctl/topic/set_retention.go
+++ b/pkg/ctl/topic/set_retention.go
@@ -60,7 +60,8 @@ func SetRetentionCmd(vc *cmdutils.VerbCmd) {
 
 	topicLevelPolicyNotEnabledError := cmdutils.Output{
 		Desc: "topic-level policy is not enabled",
-		Out:  "[✖]  code: 405 reason: Topic level policy is disabled, please enable broker configs of systemTopicEnabled and topicLevelPoliciesEnabled",
+		Out: "[✖]  code: 405 reason: Topic level policy is disabled, " +
+			"please enable broker configs of systemTopicEnabled and topicLevelPoliciesEnabled",
 	}
 
 	out = append(out, successOut, noTopicName, tenantNotExistError, nsNotExistError, topicLevelPolicyNotEnabledError)


### PR DESCRIPTION
### Motivation

The example command of `set-retention` for topics in pulsarctl missing the flag of `--time` and `--size`. And error msg should reminder to change the configs of `systemTopicEnabled` and `topicLevelPoliciesEnabled` in brokers to enable the topic level policy.