### PR TITLE
Add customRuntimeOptions to sinks and functions

### DIFF
--- a/pkg/pulsar/utils/function_confg.go
+++ b/pkg/pulsar/utils/function_confg.go
@@ -68,6 +68,8 @@ type FunctionConfig struct {
 	// A generalized way of specifying inputs
 	InputSpecs map[string]ConsumerConfig `json:"inputSpecs,omitempty" yaml:"inputSpecs"`
 
+	CustomRuntimeOptions string `json:"customRuntimeOptions,omitempty" yaml:"customRuntimeOptions"`
+
 	// This is a map of secretName(aka how the secret is going to be
 	// accessed in the function via context) to an object that
 	// encapsulates how the secret is fetched by the underlying

--- a/pkg/pulsar/utils/sink_config.go
+++ b/pkg/pulsar/utils/sink_config.go
@@ -44,6 +44,8 @@ type SinkConfig struct {
 	InputSpecs            map[string]ConsumerConfig `json:"inputSpecs,omitempty" yaml:"inputSpecs"`
 	Configs               map[string]interface{}    `json:"configs,omitempty" yaml:"configs"`
 
+	CustomRuntimeOptions string `json:"customRuntimeOptions,omitempty" yaml:"customRuntimeOptions"`
+
 	// This is a map of secretName(aka how the secret is going to be
 	// accessed in the function via context) to an object that
 	// encapsulates how the secret is fetched by the underlying


### PR DESCRIPTION
This should make the yaml config pass the customRuntimeOptions for both sinks and functions