### PR TITLE
fix: print command flags

### DIFF
--- a/pkg/cmdutils/group.go
+++ b/pkg/cmdutils/group.go
@@ -86,8 +86,6 @@ func (g *FlagGrouping) Usage(cmd *cobra.Command) error {
 		return fmt.Errorf("nil command")
 	}
 
-	group := g.groups[cmd]
-
 	usage := []string{fmt.Sprintf("Usage: %s", cmd.UseLine())}
 
 	if cmd.HasAvailableSubCommands() {
@@ -110,11 +108,9 @@ func (g *FlagGrouping) Usage(cmd *cobra.Command) error {
 		usage = append(usage, "\nAliases: "+cmd.NameAndAliases())
 	}
 
-	if group != nil {
-		for _, nfs := range group.list {
-			usage = append(usage, fmt.Sprintf("\n%s flags:", nfs.name))
-			usage = append(usage, strings.TrimRightFunc(nfs.fs.FlagUsages(), unicode.IsSpace))
-		}
+	if len(cmd.LocalFlags().FlagUsages()) != 0 && !cmd.HasAvailableSubCommands() {
+		usage = append(usage, "\nFlags:")
+		usage = append(usage, strings.TrimRightFunc(cmd.LocalFlags().FlagUsages(), unicode.IsSpace))
 	}
 
 	usage = append(usage, "\nCommon flags:")


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

Current `pulsarctl` only prints the common flags and group flags, if we are set a flag without the group in command, it doesn't print these flags.

### Reproduce

We are testing the `pulsarctl topics get-backlog-quotas -h` command, which has an `-a` flag.

### Beforce
```
git clone https://github.com/streamnative/pulsarctl
go build .
./pulsarctl topics get-backlog-quotas -h
```

output:
```
USED FOR:
    Get the backlog quota policy for a topic

REQUIRED PERMISSION:
    This command requires tenant admin permissions.

OUTPUT:

Usage: pulsarctl topics get-backlog-quotas [flags]

Examples:
    #Get the backlog quota policy for a topic
    pulsarctl topics get-backlog-quotas topic



Aliases: get-backlog-quotas, get-backlog-quotas

Common flags:
  -s, --admin-service-url string           The admin web service url that pulsarctl connects to.
      --audience string                    OAuth 2.0 audience identifier.
      --auth-params string                 Authentication parameters are used to configure the authentication provider specified by "AuthPlugin".
                                            Tls example: "tlsCertFile:val1,tlsKeyFile:val2"
                                            Token example: "authParams=file:///path/to/token/file" or "authParams=token:tokenVal"
      --auth-plugin string                 AuthPlugin is used to specify the plugin to use for authentication,
                                            the supported values are "org.apache.pulsar.client.impl.auth.AuthenticationTls"
                                            and "org.apache.pulsar.client.impl.auth.AuthenticationToken"
      --bookie-service-url string          The bookie web service url that pulsarctl connects to. (default "http://localhost:8080")
      --client-id string                   OAuth 2.0 client identifier.
  -C, --fabulous string                    toggle colorized logs (true,false,fabulous) (default "true")
  -h, --help                               help for this command
      --issuer-endpoint string             OAuth 2.0 issuer endpoint.
      --key-file string                    Path to the private key file.
      --tls-allow-insecure                 Allow TLS insecure connection
      --tls-cert-file string               File path for TLS cert used for authentication
      --tls-enable-hostname-verification   Enable TLS hostname verification
      --tls-key-file string                File path for TLS key used for authentication
      --tls-trust-cert-path string         Allow TLS trust cert file path
      --token string                       Using the token to authentication
      --token-file string                  Using the token file to authentication
  -v, --verbose int                        set log level, use 0 to silence, 4 for debugging (default 3)
  -V, --version                            show the pulsarctl version informantion

Use 'pulsarctl topics get-backlog-quotas [command] --help' for more information about a command.
```

### After 
```
git clone https://github.com/streamnative/pulsarctl
git fetch origin pull/462/head:print_command_flags
git checkout print_command_flags
go build .
./pulsarctl topics get-backlog-quotas -h
```
output:
```
USED FOR:
    Get the backlog quota policy for a topic

REQUIRED PERMISSION:
    This command requires tenant admin permissions.

OUTPUT:

Usage: pulsarctl topics get-backlog-quotas [flags]

Examples:
    #Get the backlog quota policy for a topic
    pulsarctl topics get-backlog-quotas topic



Aliases: get-backlog-quotas, get-backlog-quotas

Flags:
      --applied   Get the applied policy for the topic

Common flags:
  -s, --admin-service-url string           The admin web service url that pulsarctl connects to.
      --audience string                    OAuth 2.0 audience identifier.
      --auth-params string                 Authentication parameters are used to configure the authentication provider specified by "AuthPlugin".
                                            Tls example: "tlsCertFile:val1,tlsKeyFile:val2"
                                            Token example: "authParams=file:///path/to/token/file" or "authParams=token:tokenVal"
      --auth-plugin string                 AuthPlugin is used to specify the plugin to use for authentication,
                                            the supported values are "org.apache.pulsar.client.impl.auth.AuthenticationTls"
                                            and "org.apache.pulsar.client.impl.auth.AuthenticationToken"
      --bookie-service-url string          The bookie web service url that pulsarctl connects to. (default "http://localhost:8080")
      --client-id string                   OAuth 2.0 client identifier.
  -C, --fabulous string                    toggle colorized logs (true,false,fabulous) (default "true")
  -h, --help                               help for this command
      --issuer-endpoint string             OAuth 2.0 issuer endpoint.
      --key-file string                    Path to the private key file.
      --tls-allow-insecure                 Allow TLS insecure connection
      --tls-cert-file string               File path for TLS cert used for authentication
      --tls-enable-hostname-verification   Enable TLS hostname verification
      --tls-key-file string                File path for TLS key used for authentication
      --tls-trust-cert-path string         Allow TLS trust cert file path
      --token string                       Using the token to authentication
      --token-file string                  Using the token file to authentication
  -v, --verbose int                        set log level, use 0 to silence, 4 for debugging (default 3)
  -V, --version                            show the pulsarctl version informantion

Use 'pulsarctl topics get-backlog-quotas [command] --help' for more information about a command.
```

When fixed, it will output `Flags:
      --applied   Get the applied policy for the topic`.
