### PR TITLE
tests: increment the wait time for the test command

### DIFF
--- a/pkg/ctl/topic/max_consumers_test.go
+++ b/pkg/ctl/topic/max_consumers_test.go
@@ -30,12 +30,13 @@ func TestMaxConsumers(t *testing.T) {
 	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
 	assert.Nil(t, execErr)
 
+	time.Sleep(defaultWaitTime)
 	setArgs := []string{"set-max-consumers", topicName, "-c", "20"}
 	setOut, execErr, _, _ := TestTopicCommands(SetMaxConsumersCmd, setArgs)
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Set max number of consumers successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getArgs := []string{"get-max-consumers", topicName}
 	getOut, execErr, _, _ := TestTopicCommands(GetMaxConsumersCmd, getArgs)
 	assert.Nil(t, execErr)
@@ -46,7 +47,7 @@ func TestMaxConsumers(t *testing.T) {
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Remove max number of consumers successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getArgs = []string{"get-max-consumers", topicName}
 	getOut, execErr, _, _ = TestTopicCommands(GetMaxConsumersCmd, getArgs)
 	assert.Nil(t, execErr)

--- a/pkg/ctl/topic/max_producers_test.go
+++ b/pkg/ctl/topic/max_producers_test.go
@@ -30,12 +30,13 @@ func TestMaxProducers(t *testing.T) {
 	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
 	assert.Nil(t, execErr)
 
+	time.Sleep(defaultWaitTime)
 	setArgs := []string{"set-max-producers", topicName, "-p", "20"}
 	setOut, execErr, _, _ := TestTopicCommands(SetMaxProducersCmd, setArgs)
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Set max number of producers successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getArgs := []string{"get-max-producers", topicName}
 	getOut, execErr, _, _ := TestTopicCommands(GetMaxProducersCmd, getArgs)
 	assert.Nil(t, execErr)
@@ -46,7 +47,7 @@ func TestMaxProducers(t *testing.T) {
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Remove max number of producers successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getArgs = []string{"get-max-producers", topicName}
 	getOut, execErr, _, _ = TestTopicCommands(GetMaxProducersCmd, getArgs)
 	assert.Nil(t, execErr)

--- a/pkg/ctl/topic/max_unack_messages_per_consumer_test.go
+++ b/pkg/ctl/topic/max_unack_messages_per_consumer_test.go
@@ -30,12 +30,13 @@ func TestMaxUnackMessagesPerConsumer(t *testing.T) {
 	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
 	assert.Nil(t, execErr)
 
+	time.Sleep(defaultWaitTime)
 	setArgs := []string{"set-max-unacked-messages-per-consumer", topicName, "-m", "20"}
 	setOut, execErr, _, _ := TestTopicCommands(SetMaxUnackMessagesPerConsumerCmd, setArgs)
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Set max unacked messages per consumer successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getArgs := []string{"get-max-unacked-messages-per-consumer", topicName}
 	getOut, execErr, _, _ := TestTopicCommands(GetMaxUnackMessagesPerConsumerCmd, getArgs)
 	assert.Nil(t, execErr)
@@ -46,7 +47,7 @@ func TestMaxUnackMessagesPerConsumer(t *testing.T) {
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Remove max unacked messages per consumer successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getArgs = []string{"get-max-unacked-messages-per-consumer", topicName}
 	getOut, execErr, _, _ = TestTopicCommands(GetMaxUnackMessagesPerConsumerCmd, getArgs)
 	assert.Nil(t, execErr)

--- a/pkg/ctl/topic/max_unack_messages_per_subscription_test.go
+++ b/pkg/ctl/topic/max_unack_messages_per_subscription_test.go
@@ -35,7 +35,7 @@ func TestMaxUnackMessagesPerSubscription(t *testing.T) {
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Set max unacked messages per subscription successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getArgs := []string{"get-max-unacked-messages-per-subscription", topicName}
 	getOut, execErr, _, _ := TestTopicCommands(GetMaxUnackMessagesPerSubscriptionCmd, getArgs)
 	assert.Nil(t, execErr)
@@ -46,7 +46,7 @@ func TestMaxUnackMessagesPerSubscription(t *testing.T) {
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Remove max unacked messages per subscription successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getArgs = []string{"get-max-unacked-messages-per-subscription", topicName}
 	getOut, execErr, _, _ = TestTopicCommands(GetMaxUnackMessagesPerSubscriptionCmd, getArgs)
 	assert.Nil(t, execErr)

--- a/pkg/ctl/topic/message_ttl_test.go
+++ b/pkg/ctl/topic/message_ttl_test.go
@@ -35,7 +35,7 @@ func TestMessageTTL(t *testing.T) {
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Set message TTL successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getTTLArgs := []string{"get-message-ttl", topicName}
 	getOut, execErr, _, _ := TestTopicCommands(GetMessageTTLCmd, getTTLArgs)
 	assert.Nil(t, execErr)
@@ -46,7 +46,7 @@ func TestMessageTTL(t *testing.T) {
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Remove message TTL successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getTTLArgs = []string{"get-message-ttl", topicName}
 	getOut, execErr, _, _ = TestTopicCommands(GetMessageTTLCmd, getTTLArgs)
 	assert.Nil(t, execErr)

--- a/pkg/ctl/topic/persistence_test.go
+++ b/pkg/ctl/topic/persistence_test.go
@@ -37,7 +37,7 @@ func TestPersistence(t *testing.T) {
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Set persistence successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getArgs := []string{"get-persistence", topicName}
 	getOut, execErr, _, _ := TestTopicCommands(GetPersistenceCmd, getArgs)
 	var persistenceData utils.PersistenceData
@@ -56,7 +56,7 @@ func TestPersistence(t *testing.T) {
 	assert.Nil(t, execErr)
 	assert.Equal(t, setOut.String(), "Remove persistence successfully for ["+topicName+"]\n")
 
-	time.Sleep(time.Duration(1) * time.Second)
+	time.Sleep(defaultWaitTime)
 	getArgs = []string{"get-persistence", topicName}
 	getOut, execErr, _, _ = TestTopicCommands(GetPersistenceCmd, getArgs)
 	err = json.Unmarshal(getOut.Bytes(), &persistenceData)

--- a/pkg/ctl/topic/test_help.go
+++ b/pkg/ctl/topic/test_help.go
@@ -19,12 +19,15 @@ package topic
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/streamnative/pulsarctl/pkg/cmdutils"
 
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
 )
+
+const defaultWaitTime = 5 * time.Second
 
 func TestTopicCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (out *bytes.Buffer,
 	execErr, nameErr, err error) {


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

Fix: #468

The waiting time of the old version was 1s, I increased the waiting time to 5s, it looks enough for tests.