### PR TITLE
fix: add miss fields to PersistentTopicInternalStats

### DIFF
--- a/pkg/pulsar/utils/data.go
+++ b/pkg/pulsar/utils/data.go
@@ -257,6 +257,8 @@ type PersistentTopicInternalStats struct {
 	State                              string                 `json:"state"`
 	Ledgers                            []LedgerInfo           `json:"ledgers"`
 	Cursors                            map[string]CursorStats `json:"cursors"`
+	SchemaLedgers                      []SchemaLedger         `json:"schemaLedgers"`
+	CompactedLedger                    CompactedLedger        `json:"compactedLedger"`
 }
 
 type LedgerInfo struct {
@@ -393,4 +395,20 @@ type DispatchRateData struct {
 type PublishRateData struct {
 	PublishThrottlingRateInMsg  int64 `json:"publishThrottlingRateInMsg"`
 	PublishThrottlingRateInByte int64 `json:"publishThrottlingRateInByte"`
+}
+
+type SchemaLedger struct {
+	LedgerID    int64 `json:"ledgerId"`
+	Entries     int64 `json:"entries"`
+	Size        int64 `json:"size"`
+	Timestamp   int64 `json:"timestamp"`
+	IsOffloaded bool  `json:"isOffloaded"`
+}
+
+type CompactedLedger struct {
+	LedgerID        int64 `json:"ledgerId"`
+	Entries         int64 `json:"entries"`
+	Size            int64 `json:"size"`
+	Offloaded       bool  `json:"offloaded"`
+	UnderReplicated bool  `json:"underReplicated"`
 }


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

Fix: https://github.com/streamnative/pulsarctl/issues/474

Add `schemaLedgers` and `compactedLedger` fields to `PersistentTopicInternalStats` stuct.

