### PR TITLE
fix: improve parse response avoid parse the empty body

### DIFF
--- a/pkg/ctl/namespace/get_offload_deletion_lag.go
+++ b/pkg/ctl/namespace/get_offload_deletion_lag.go
@@ -67,14 +67,13 @@ func doGetOffloadDeletionLag(vc *cmdutils.VerbCmd) error {
 
 	admin := cmdutils.NewPulsarClient()
 	ms, err := admin.Namespaces().GetOffloadDeleteLag(*ns)
-	if err == nil {
-		t, _ := time.ParseDuration(fmt.Sprintf("%dms", ms))
-		vc.Command.Printf("The offload deletion lag of the namespace %s is %f minute(s)\n",
-			ns.String(), t.Minutes())
-	} else if ms == 0 {
-		vc.Command.Printf("The offload deletion lag of the namespace %s is not set\n", ns.String())
-		err = nil
+	if err != nil {
+		return err
 	}
 
-	return err
+	t, _ := time.ParseDuration(fmt.Sprintf("%dms", ms))
+	vc.Command.Printf("The offload deletion lag of the namespace %s is %f minute(s)\n",
+		ns.String(), t.Minutes())
+
+	return nil
 }

--- a/pkg/ctl/namespace/offload_deletion_test.go
+++ b/pkg/ctl/namespace/offload_deletion_test.go
@@ -62,7 +62,7 @@ func TestOffloadDeletionLagCmd(t *testing.T) {
 	out, execErr, _, _ = TestNamespaceCommands(GetOffloadDeletionLagCmd, args)
 	assert.Nil(t, execErr)
 	assert.Equal(t,
-		fmt.Sprintf("The offload deletion lag of the namespace %s is not set\n", ns),
+		fmt.Sprintf("The offload deletion lag of the namespace %s is %f minute(s)\n", ns, 0.000000),
 		out.String())
 
 }

--- a/pkg/pulsar/namespace.go
+++ b/pkg/pulsar/namespace.go
@@ -447,12 +447,10 @@ func (n *namespaces) SetSchemaValidationEnforced(namespace utils.NameSpaceName, 
 }
 
 func (n *namespaces) GetSchemaValidationEnforced(namespace utils.NameSpaceName) (bool, error) {
+	var result bool
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "schemaValidationEnforced")
-	r, err := n.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
-	if err != nil {
-		return false, err
-	}
-	return strconv.ParseBool(string(r))
+	err := n.pulsar.Client.Get(endpoint, &result)
+	return result, err
 }
 
 func (n *namespaces) SetSchemaAutoUpdateCompatibilityStrategy(namespace utils.NameSpaceName,
@@ -486,12 +484,10 @@ func (n *namespaces) SetOffloadDeleteLag(namespace utils.NameSpaceName, timeMs i
 }
 
 func (n *namespaces) GetOffloadDeleteLag(namespace utils.NameSpaceName) (int64, error) {
+	var result int64
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "offloadDeletionLagMs")
-	b, err := n.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
-	if err != nil {
-		return -1, err
-	}
-	return strconv.ParseInt(string(b), 10, 64)
+	err := n.pulsar.Client.Get(endpoint, &result)
+	return result, err
 }
 
 func (n *namespaces) SetMaxConsumersPerSubscription(namespace utils.NameSpaceName, max int) error {
@@ -500,12 +496,10 @@ func (n *namespaces) SetMaxConsumersPerSubscription(namespace utils.NameSpaceNam
 }
 
 func (n *namespaces) GetMaxConsumersPerSubscription(namespace utils.NameSpaceName) (int, error) {
+	var result int
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxConsumersPerSubscription")
-	b, err := n.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
-	if err != nil {
-		return -1, err
-	}
-	return strconv.Atoi(string(b))
+	err := n.pulsar.Client.Get(endpoint, &result)
+	return result, err
 }
 
 func (n *namespaces) SetOffloadThreshold(namespace utils.NameSpaceName, threshold int64) error {
@@ -514,12 +508,10 @@ func (n *namespaces) SetOffloadThreshold(namespace utils.NameSpaceName, threshol
 }
 
 func (n *namespaces) GetOffloadThreshold(namespace utils.NameSpaceName) (int64, error) {
+	var result int64
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "offloadThreshold")
-	b, err := n.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
-	if err != nil {
-		return -1, err
-	}
-	return strconv.ParseInt(string(b), 10, 64)
+	err := n.pulsar.Client.Get(endpoint, &result)
+	return result, err
 }
 
 func (n *namespaces) SetMaxConsumersPerTopic(namespace utils.NameSpaceName, max int) error {
@@ -528,12 +520,10 @@ func (n *namespaces) SetMaxConsumersPerTopic(namespace utils.NameSpaceName, max 
 }
 
 func (n *namespaces) GetMaxConsumersPerTopic(namespace utils.NameSpaceName) (int, error) {
+	var result int
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxConsumersPerTopic")
-	b, err := n.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
-	if err != nil {
-		return -1, err
-	}
-	return strconv.Atoi(string(b))
+	err := n.pulsar.Client.Get(endpoint, &result)
+	return result, err
 }
 
 func (n *namespaces) SetCompactionThreshold(namespace utils.NameSpaceName, threshold int64) error {
@@ -542,12 +532,10 @@ func (n *namespaces) SetCompactionThreshold(namespace utils.NameSpaceName, thres
 }
 
 func (n *namespaces) GetCompactionThreshold(namespace utils.NameSpaceName) (int64, error) {
+	var result int64
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "compactionThreshold")
-	b, err := n.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
-	if err != nil {
-		return -1, err
-	}
-	return strconv.ParseInt(string(b), 10, 64)
+	err := n.pulsar.Client.Get(endpoint, &result)
+	return result, err
 }
 
 func (n *namespaces) SetMaxProducersPerTopic(namespace utils.NameSpaceName, max int) error {
@@ -556,12 +544,10 @@ func (n *namespaces) SetMaxProducersPerTopic(namespace utils.NameSpaceName, max 
 }
 
 func (n *namespaces) GetMaxProducersPerTopic(namespace utils.NameSpaceName) (int, error) {
+	var result int
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxProducersPerTopic")
-	b, err := n.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
-	if err != nil {
-		return -1, err
-	}
-	return strconv.Atoi(string(b))
+	err := n.pulsar.Client.Get(endpoint, &result)
+	return result, err
 }
 
 func (n *namespaces) GetNamespaceReplicationClusters(namespace string) ([]string, error) {


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation
The Pulsar API sometimes returns an empty body, when we use `strconv` to parse this body will get an error, we should avoid this problem.

