### PR TITLE
Fix creating a tenant without admin role parameters

### DIFF
--- a/pkg/ctl/tenant/create.go
+++ b/pkg/ctl/tenant/create.go
@@ -65,7 +65,7 @@ func createTenantCmd(vc *cmdutils.VerbCmd) {
 			&tenantData.AdminRoles,
 			"admin-roles",
 			"r",
-			[]string{""},
+			[]string{},
 			"Allowed admins to access the tenant")
 		set.StringSliceVarP(
 			&tenantData.AllowedClusters,


### PR DESCRIPTION
Fix the issue that the default behavior of creating a tenant with an empty role list. the result of getting tenant should be same with tenant which is created by pulsar-admin.

```shell
// created by pulsar-admin
{
  "adminRoles": [],
  "allowedClusters": [
    "test-pulsar-sn-platform"
  ]
}
// created by pulsarctl
{
  "adminRoles": [
    ""
  ],
  "allowedClusters": [
    "test-pulsar-sn-platform"
  ]
}
```