### PR TITLE
ParseAuthAction supports new  actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ pulsarctl*.tar.gz
 pulsarctl-site-*.tar.gz
 release
 dist
+
+# Vscode
+.vscode

--- a/pkg/ctl/namespace/grant_permission.go
+++ b/pkg/ctl/namespace/grant_permission.go
@@ -72,7 +72,7 @@ func GrantPermissionsCmd(vc *cmdutils.VerbCmd) {
 		set.StringVar(&role, "role", "",
 			"Client role to which grant permissions")
 		set.StringSliceVar(&actions, "actions", []string{},
-			"Actions to be granted (produce,consume,functions)")
+			"Actions to be granted (produce,consume,sources,sinks,functions,packages)")
 		cobra.MarkFlagRequired(set, "role")
 		cobra.MarkFlagRequired(set, "actions")
 	})

--- a/pkg/ctl/namespace/grant_permission_test.go
+++ b/pkg/ctl/namespace/grant_permission_test.go
@@ -53,5 +53,5 @@ func TestGrantPermissionsArgsError(t *testing.T) {
 	_, execErr, _, _ := TestNamespaceCommands(GrantPermissionsCmd, args)
 	assert.NotNil(t, execErr)
 	assert.Equal(t, "The auth action only can be specified as 'produce', "+
-		"'consume', or 'functions'. Invalid auth action 'fail'", execErr.Error())
+		"'consume', 'sources', 'sinks', 'packages', or 'functions'. Invalid auth action 'fail'", execErr.Error())
 }

--- a/pkg/ctl/topic/grant_permissions.go
+++ b/pkg/ctl/topic/grant_permissions.go
@@ -55,7 +55,7 @@ func GrantPermissionCmd(vc *cmdutils.VerbCmd) {
 	actionsError := cmdutils.Output{
 		Desc: "the specified actions is not allowed.",
 		Out: "The auth action  only can be specified as 'produce', " +
-			"'consume', or 'functions'. Invalid auth action '(actions)'",
+			"'consume', 'sources', 'sinks', 'packages', or 'functions'. Invalid auth action '(actions)'",
 	}
 	out = append(out, successOut, ArgError, flagError, actionsError)
 	out = append(out, TopicNameErrors...)
@@ -80,7 +80,7 @@ func GrantPermissionCmd(vc *cmdutils.VerbCmd) {
 		set.StringVar(&role, "role", "",
 			"Client role to which grant permissions")
 		set.StringSliceVar(&actions, "actions", []string{},
-			"Actions to be granted (produce,consume,functions)")
+			"Actions to be granted (produce,consume,sources,sinks,functions,packages)")
 		cobra.MarkFlagRequired(set, "role")
 		cobra.MarkFlagRequired(set, "actions")
 	})

--- a/pkg/ctl/topic/grant_permissions_test.go
+++ b/pkg/ctl/topic/grant_permissions_test.go
@@ -123,5 +123,5 @@ func TestGrantPermissionArgError(t *testing.T) {
 	_, execErr, _, _ = TestTopicCommands(GrantPermissionCmd, args)
 	assert.NotNil(t, execErr)
 	assert.Equal(t, "The auth action only can be specified as 'produce', "+
-		"'consume', or 'functions'. Invalid auth action 'args-error-action'", execErr.Error())
+		"'consume', 'sources', 'sinks', 'packages', or 'functions'. Invalid auth action 'args-error-action'", execErr.Error())
 }

--- a/pkg/pulsar/common/auth_action.go
+++ b/pkg/pulsar/common/auth_action.go
@@ -25,6 +25,9 @@ const (
 	produce       AuthAction = "produce"
 	consume       AuthAction = "consume"
 	functionsAuth AuthAction = "functions"
+	packages      AuthAction = "packages"
+	sinks         AuthAction = "sinks"
+	sources       AuthAction = "sources"
 )
 
 func ParseAuthAction(action string) (AuthAction, error) {
@@ -35,9 +38,15 @@ func ParseAuthAction(action string) (AuthAction, error) {
 		return consume, nil
 	case "functions":
 		return functionsAuth, nil
+	case "packages":
+		return packages, nil
+	case "sinks":
+		return sinks, nil
+	case "sources":
+		return sources, nil
 	default:
 		return "", errors.Errorf("The auth action only can be specified as 'produce', "+
-			"'consume', or 'functions'. Invalid auth action '%s'", action)
+			"'consume', 'sources', 'sinks', 'packages', or 'functions'. Invalid auth action '%s'", action)
 	}
 }
 


### PR DESCRIPTION
pulsar admin support 6 actions, but function ParseAuthAction only support 3 of them.

https://github.com/apache/pulsar/blob/branch-2.8/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/AuthAction.java