### PR TITLE
Rename the subcommands of the topics permission related

### DIFF
--- a/pkg/ctl/topic/get_permissions.go
+++ b/pkg/ctl/topic/get_permissions.go
@@ -32,7 +32,7 @@ func GetPermissionsCmd(vc *cmdutils.VerbCmd) {
 	var examples []cmdutils.Example
 	get := cmdutils.Example{
 		Desc:    "Get the permissions of a topic (topic-name)",
-		Command: "pulsarctl topic get-permissions (topic-name)",
+		Command: "pulsarctl topic permissions (topic-name)",
 	}
 	examples = append(examples, get)
 	desc.CommandExamples = examples
@@ -52,7 +52,7 @@ func GetPermissionsCmd(vc *cmdutils.VerbCmd) {
 	desc.CommandOutput = out
 
 	vc.SetDescription(
-		"get-permissions",
+		"permissions",
 		"Get the permissions of a topic",
 		desc.ToString(),
 		desc.ExampleToString(),

--- a/pkg/ctl/topic/get_permissions_test.go
+++ b/pkg/ctl/topic/get_permissions_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestGetPermissionsArgError(t *testing.T) {
-	args := []string{"get-permissions"}
+	args := []string{"permissions"}
 	_, _, nameErr, _ := TestTopicCommands(GetPermissionsCmd, args)
 	assert.NotNil(t, nameErr)
 	assert.Equal(t, "the topic name is not specified or the topic name is specified more than one", nameErr.Error())

--- a/pkg/ctl/topic/grant_permissions.go
+++ b/pkg/ctl/topic/grant_permissions.go
@@ -36,7 +36,7 @@ func GrantPermissionCmd(vc *cmdutils.VerbCmd) {
 	var examples []cmdutils.Example
 	grant := cmdutils.Example{
 		Desc:    "Grant permissions to a client on a single topic (topic-name)",
-		Command: "pulsarctl topic grant-permissions --role (role) --actions (action-1) --actions (action-2) (topic-name)",
+		Command: "pulsarctl topic grant-permission --role (role) --actions (action-1) --actions (action-2) (topic-name)",
 	}
 	examples = append(examples, grant)
 	desc.CommandExamples = examples
@@ -63,7 +63,7 @@ func GrantPermissionCmd(vc *cmdutils.VerbCmd) {
 	desc.CommandOutput = out
 
 	vc.SetDescription(
-		"grant-permissions",
+		"grant-permission",
 		"Grant permissions to a client on a topic",
 		desc.ToString(),
 		desc.ExampleToString(),

--- a/pkg/ctl/topic/grant_permissions_test.go
+++ b/pkg/ctl/topic/grant_permissions_test.go
@@ -30,7 +30,7 @@ func TestGrantPermissionToNonPartitionedTopic(t *testing.T) {
 	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
 	assert.Nil(t, execErr)
 
-	args = []string{"get-permissions", "test-grant-permission-non-partitioned-topic"}
+	args = []string{"permissions", "test-grant-permission-non-partitioned-topic"}
 	out, execErr, _, _ := TestTopicCommands(GetPermissionsCmd, args)
 	assert.Nil(t, execErr)
 
@@ -42,7 +42,7 @@ func TestGrantPermissionToNonPartitionedTopic(t *testing.T) {
 
 	assert.Equal(t, map[string][]common.AuthAction{}, permissions)
 
-	args = []string{"grant-permissions",
+	args = []string{"grant-permission",
 		"--role", "grant-non-partitioned-role",
 		"--actions", "produce",
 		"test-grant-permission-non-partitioned-topic",
@@ -50,7 +50,7 @@ func TestGrantPermissionToNonPartitionedTopic(t *testing.T) {
 	_, execErr, _, _ = TestTopicCommands(GrantPermissionCmd, args)
 	assert.Nil(t, execErr)
 
-	args = []string{"get-permissions", "test-grant-permission-non-partitioned-topic"}
+	args = []string{"permissions", "test-grant-permission-non-partitioned-topic"}
 	out, execErr, _, _ = TestTopicCommands(GetPermissionsCmd, args)
 	assert.Nil(t, execErr)
 
@@ -67,7 +67,7 @@ func TestGrantPermissionToPartitionedTopic(t *testing.T) {
 	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
 	assert.Nil(t, execErr)
 
-	args = []string{"get-permissions", "test-grant-permission-partitioned-topic"}
+	args = []string{"permissions", "test-grant-permission-partitioned-topic"}
 	out, execErr, _, _ := TestTopicCommands(GetPermissionsCmd, args)
 	assert.Nil(t, execErr)
 
@@ -79,7 +79,7 @@ func TestGrantPermissionToPartitionedTopic(t *testing.T) {
 
 	assert.Equal(t, map[string][]common.AuthAction{}, permissions)
 
-	args = []string{"grant-permissions",
+	args = []string{"grant-permission",
 		"--role", "grant-partitioned-role",
 		"--actions", "consume",
 		"test-grant-permission-partitioned-topic",
@@ -87,7 +87,7 @@ func TestGrantPermissionToPartitionedTopic(t *testing.T) {
 	_, execErr, _, _ = TestTopicCommands(GrantPermissionCmd, args)
 	assert.Nil(t, execErr)
 
-	args = []string{"get-permissions", "test-grant-permission-partitioned-topic"}
+	args = []string{"permissions", "test-grant-permission-partitioned-topic"}
 	out, execErr, _, _ = TestTopicCommands(GetPermissionsCmd, args)
 	assert.Nil(t, execErr)
 
@@ -100,22 +100,22 @@ func TestGrantPermissionToPartitionedTopic(t *testing.T) {
 }
 
 func TestGrantPermissionArgError(t *testing.T) {
-	args := []string{"grant-permissions", "--role", "test-arg-error-role", "--actions", "produce"}
+	args := []string{"grant-permission", "--role", "test-arg-error-role", "--actions", "produce"}
 	_, _, nameErr, _ := TestTopicCommands(GrantPermissionCmd, args)
 	assert.NotNil(t, nameErr)
 	assert.Equal(t, "the topic name is not specified or the topic name is specified more than one", nameErr.Error())
 
-	args = []string{"grant-permissions", "args-error-topic"}
+	args = []string{"grant-permission", "args-error-topic"}
 	_, _, _, err := TestTopicCommands(GrantPermissionCmd, args)
 	assert.NotNil(t, err)
 	assert.Equal(t, "required flag(s) \"actions\", \"role\" not set", err.Error())
 
-	args = []string{"grant-permissions", "--role", "", "--actions", "produce", "role-empty-topic"}
+	args = []string{"grant-permission", "--role", "", "--actions", "produce", "role-empty-topic"}
 	_, execErr, _, _ := TestTopicCommands(GrantPermissionCmd, args)
 	assert.NotNil(t, execErr)
 	assert.Equal(t, "Invalid role name", execErr.Error())
 
-	args = []string{"grant-permissions",
+	args = []string{"grant-permission",
 		"--role", "args-error-role",
 		"--actions", "args-error-action",
 		"invalid-actions-topic",

--- a/pkg/ctl/topic/revoke_permissions.go
+++ b/pkg/ctl/topic/revoke_permissions.go
@@ -57,7 +57,7 @@ func RevokePermissions(vc *cmdutils.VerbCmd) {
 	desc.CommandOutput = out
 
 	vc.SetDescription(
-		"revoke-permissions",
+		"revoke-permission",
 		"Revoke a client role permissions on a topic",
 		desc.ToString(),
 		desc.ExampleToString(),

--- a/pkg/ctl/topic/revoke_permissions.go
+++ b/pkg/ctl/topic/revoke_permissions.go
@@ -36,7 +36,7 @@ func RevokePermissions(vc *cmdutils.VerbCmd) {
 	var examples []cmdutils.Example
 	revoke := cmdutils.Example{
 		Desc:    "Revoke permissions of a topic (topic-name)",
-		Command: "pulsarctl topic revoke-permissions --role (role) (topic-name)",
+		Command: "pulsarctl topic revoke-permission --role (role) (topic-name)",
 	}
 	examples = append(examples, revoke)
 	desc.CommandExamples = examples

--- a/pkg/ctl/topic/revoke_permissions_test.go
+++ b/pkg/ctl/topic/revoke_permissions_test.go
@@ -40,7 +40,7 @@ func TestRevokePermissionsOnNonPartitionedTopic(t *testing.T) {
 }
 
 func testRevokePermission(t *testing.T, topic string) {
-	args := []string{"grant-permissions",
+	args := []string{"grant-permission",
 		"--role", "revoke-test-role",
 		"--actions", "produce",
 		topic,
@@ -48,7 +48,7 @@ func testRevokePermission(t *testing.T, topic string) {
 	_, execErr, _, _ := TestTopicCommands(GrantPermissionCmd, args)
 	assert.Nil(t, execErr)
 
-	args = []string{"get-permissions", topic}
+	args = []string{"permissions", topic}
 	out, execErr, _, _ := TestTopicCommands(GetPermissionsCmd, args)
 	assert.Nil(t, execErr)
 
@@ -65,7 +65,7 @@ func testRevokePermission(t *testing.T, topic string) {
 	_, execErr, _, _ = TestTopicCommands(RevokePermissions, args)
 	assert.Nil(t, execErr)
 
-	args = []string{"get-permissions", topic}
+	args = []string{"permissions", topic}
 	out, execErr, _, _ = TestTopicCommands(GetPermissionsCmd, args)
 	assert.Nil(t, execErr)
 

--- a/pkg/ctl/topic/revoke_permissions_test.go
+++ b/pkg/ctl/topic/revoke_permissions_test.go
@@ -61,7 +61,7 @@ func testRevokePermission(t *testing.T, topic string) {
 	assert.Equal(t, 1, len(permissions["revoke-test-role"]))
 	assert.Equal(t, "produce", permissions["revoke-test-role"][0].String())
 
-	args = []string{"revoke-permissions", "--role", "revoke-test-role", topic}
+	args = []string{"revoke-permission", "--role", "revoke-test-role", topic}
 	_, execErr, _, _ = TestTopicCommands(RevokePermissions, args)
 	assert.Nil(t, execErr)
 
@@ -79,17 +79,17 @@ func testRevokePermission(t *testing.T, topic string) {
 }
 
 func TestRevokePermissionsArgError(t *testing.T) {
-	args := []string{"revoke-permissions", "--role", "args-error-role"}
+	args := []string{"revoke-permission", "--role", "args-error-role"}
 	_, _, nameErr, _ := TestTopicCommands(RevokePermissions, args)
 	assert.NotNil(t, nameErr)
 	assert.Equal(t, "the topic name is not specified or the topic name is specified more than one", nameErr.Error())
 
-	args = []string{"revoke-permissions", "--role", "", "empty-role-topic"}
+	args = []string{"revoke-permission", "--role", "", "empty-role-topic"}
 	_, execErr, _, _ := TestTopicCommands(RevokePermissions, args)
 	assert.NotNil(t, execErr)
 	assert.Equal(t, "Invalid role name", execErr.Error())
 
-	args = []string{"revoke-permissions", "not-specified-role-topic"}
+	args = []string{"revoke-permission", "not-specified-role-topic"}
 	_, _, _, err := TestTopicCommands(RevokePermissions, args)
 	assert.NotNil(t, err)
 	assert.Equal(t, "required flag(s) \"role\" not set", err.Error())


### PR DESCRIPTION
## Motivation
To keep subcommand of the topics same with namespaces and pulsar-admin. 

According to these docs, the subcommands of topics are different from `pulsarctl namespace` and `pulsar-admin topics/namespaces`

https://pulsar.apache.org/tools/pulsar-admin/2.10.0-SNAPSHOT/#-em-grant-permission-em--58
https://docs.streamnative.io/pulsarctl/v2.7.0.7/#-em-permissions-em-

```shell
pulsarctl topics get-permissions
pulsarctl topics grant-permissions
pulsarctl topics revoke-permissions
```
```shell
pulsarctl namespaces permissions
pulsarctl namespaces grant-permission
pulsarctl namespaces revoke-permission
```

```shell
# topics
pulsar-admin topics permissions
pulsar-admin topics grant-permission
pulsar-admin topics revoke-permission
# namespaces
pulsar-admin namespaces permissions
pulsar-admin namespaces grant-permission
pulsar-admin namespaces revoke-permission
```