### PR TITLE
fix: improve new client with auth provider

### DIFF
--- a/pkg/auth/auth_provider.go
+++ b/pkg/auth/auth_provider.go
@@ -20,10 +20,8 @@ package auth
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 
 	"github.com/streamnative/pulsarctl/pkg/pulsar/common"
 )
@@ -41,8 +39,10 @@ type Transport struct {
 
 func GetAuthProvider(config *common.Config) (*Provider, error) {
 	var provider Provider
-	defaultTransport := GetDefaultTransport(config)
-	var err error
+	defaultTransport, err := NewDefaultTransport(config)
+	if err != nil {
+		return nil, err
+	}
 	switch config.AuthPlugin {
 	case TLSPluginShortName:
 		fallthrough
@@ -68,7 +68,18 @@ func GetAuthProvider(config *common.Config) (*Provider, error) {
 	return &provider, err
 }
 
+// GetDefaultTransport gets a default transport.
+// Deprecated: Use NewDefaultTransport instead.
 func GetDefaultTransport(config *common.Config) http.RoundTripper {
+	transport, err := NewDefaultTransport(config)
+	if err != nil {
+		panic(err)
+	}
+
+	return transport
+}
+
+func NewDefaultTransport(config *common.Config) (http.RoundTripper, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: config.TLSAllowInsecureConnection,
@@ -76,13 +87,12 @@ func GetDefaultTransport(config *common.Config) http.RoundTripper {
 	if len(config.TLSTrustCertsFilePath) > 0 {
 		rootCA, err := ioutil.ReadFile(config.TLSTrustCertsFilePath)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error loading certificate authority:", err)
-			os.Exit(1)
+			return nil, err
 		}
 		tlsConfig.RootCAs = x509.NewCertPool()
 		tlsConfig.RootCAs.AppendCertsFromPEM(rootCA)
 	}
 	transport.MaxIdleConnsPerHost = 10
 	transport.TLSClientConfig = tlsConfig
-	return transport
+	return transport, nil
 }

--- a/pkg/pulsar/admin.go
+++ b/pkg/pulsar/admin.go
@@ -85,8 +85,24 @@ func New(config *common.Config) (Client, error) {
 	return c, err
 }
 
+// NewWithAuthProvider creates a client with auth provider.
+// Deprecated: Use NewPulsarClientWithAuthProvider instead.
 func NewWithAuthProvider(config *common.Config, authProvider auth.Provider) Client {
-	defaultTransport := auth.GetDefaultTransport(config)
+	client, err := NewPulsarClientWithAuthProvider(config, authProvider)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// NewPulsarClientWithAuthProvider create a client with auth provider.
+func NewPulsarClientWithAuthProvider(config *common.Config,
+	authProvider auth.Provider) (Client, error) {
+	defaultTransport, err := auth.NewDefaultTransport(config)
+	if err != nil {
+		return nil, err
+	}
+
 	authProvider.WithTransport(defaultTransport)
 
 	c := &pulsarClient{
@@ -100,7 +116,8 @@ func NewWithAuthProvider(config *common.Config, authProvider auth.Provider) Clie
 			},
 		},
 	}
-	return c
+
+	return c, nil
 }
 
 func (c *pulsarClient) endpoint(componentPath string, parts ...string) string {


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

`NewDefaultTransport` will call the `os.Exit(1)` when has an error,  which will cause the program to exit abnormally, so I use `panic` instead, and I also add some methods that can return an error to avoid `panic`.

