### PR TITLE
Fix build error in pulsarctl

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,7 +45,7 @@ build() {
 function build_doc() {
   echo ${version} > VERSION
   make cli
-  mv pulsarctl-site-${version}.tar.gz ${ASSETSDIR}
+  mv pulsarctl-site-${version}.tar.gz ${ASSETS_DIR}
 }
 
 build amd64 linux


### PR DESCRIPTION
# Motivation

Build failure:
```
mv: missing destination file operand after 'pulsarctl-site-2.9.1.0-rc2.tar.gz'
Try 'mv --help' for more information.
+ echo 'Releasing pulsarctl'
Releasing pulsarctl
```