### PR TITLE
fix: register the dispatch rate command

### DIFF
--- a/pkg/ctl/topic/topic.go
+++ b/pkg/ctl/topic/topic.go
@@ -93,6 +93,8 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 		GetInactiveTopicCmd,
 		SetInactiveTopicCmd,
 		RemoveInactiveTopicCmd,
+		SetDispatchRateCmd,
+		RemoveDispatchRateCmd,
 	}
 
 	cmdutils.AddVerbCmds(flagGrouping, resourceCmd, commands...)


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

Fix register the dispatch rate command:

```
pulsarctl topics set-dispatch-rate
pulsarctl topics remove-dispatch-rate
```