### PR TITLE
fix: update type in namespace policies

### DIFF
--- a/pkg/ctl/namespace/policies_test.go
+++ b/pkg/ctl/namespace/policies_test.go
@@ -39,7 +39,7 @@ func TestPolicesCommand(t *testing.T) {
 	err = json.Unmarshal(out.Bytes(), &police)
 	assert.Nil(t, err)
 
-	assert.Equal(t, police.DeduplicationEnabled, false)
+	assert.Nil(t, police.DeduplicationEnabled)
 	assert.Equal(t, police.Deleted, false)
 	for key, value := range police.ClusterSubscribeRate {
 		exceptedValue := utils.SubscribeRate{

--- a/pkg/pulsar/utils/policies.go
+++ b/pkg/pulsar/utils/policies.go
@@ -31,16 +31,16 @@ type Policies struct {
 	Persistence                 *PersistencePolicies              `json:"persistence"`
 	RetentionPolicies           *RetentionPolicies                `json:"retention_policies"`
 	SchemaValidationEnforced    bool                              `json:"schema_validation_enforced"`
-	DeduplicationEnabled        bool                              `json:"deduplicationEnabled"`
+	DeduplicationEnabled        *bool                             `json:"deduplicationEnabled"`
 	Deleted                     bool                              `json:"deleted"`
 	EncryptionRequired          bool                              `json:"encryption_required"`
-	MessageTTLInSeconds         int                               `json:"message_ttl_in_seconds"`
-	MaxProducersPerTopic        int                               `json:"max_producers_per_topic"`
-	MaxConsumersPerTopic        int                               `json:"max_consumers_per_topic"`
-	MaxConsumersPerSubscription int                               `json:"max_consumers_per_subscription"`
-	CompactionThreshold         int64                             `json:"compaction_threshold"`
+	MessageTTLInSeconds         *int                              `json:"message_ttl_in_seconds"`
+	MaxProducersPerTopic        *int                              `json:"max_producers_per_topic"`
+	MaxConsumersPerTopic        *int                              `json:"max_consumers_per_topic"`
+	MaxConsumersPerSubscription *int                              `json:"max_consumers_per_subscription"`
+	CompactionThreshold         *int64                            `json:"compaction_threshold"`
 	OffloadThreshold            int64                             `json:"offload_threshold"`
-	OffloadDeletionLagMs        int64                             `json:"offload_deletion_lag_ms"`
+	OffloadDeletionLagMs        *int64                            `json:"offload_deletion_lag_ms"`
 	AntiAffinityGroup           string                            `json:"antiAffinityGroup"`
 	ReplicationClusters         []string                          `json:"replication_clusters"`
 	LatencyStatsSampleRate      map[string]int                    `json:"latency_stats_sample_rate"`
@@ -50,7 +50,7 @@ type Policies struct {
 	ReplicatorDispatchRate      map[string]DispatchRate           `json:"replicatorDispatchRate"`
 	PublishMaxMessageRate       map[string]PublishRate            `json:"publishMaxMessageRate"`
 	ClusterSubscribeRate        map[string]SubscribeRate          `json:"clusterSubscribeRate"`
-	TopicAutoCreationConfig     TopicAutoCreationConfig           `json:"autoTopicCreationOverride"`
+	TopicAutoCreationConfig     *TopicAutoCreationConfig          `json:"autoTopicCreationOverride"`
 	SchemaCompatibilityStrategy SchemaCompatibilityStrategy       `json:"schema_auto_update_compatibility_strategy"`
 	AuthPolicies                common.AuthPolicies               `json:"auth_policies"`
 	SubscriptionAuthMode        SubscriptionAuthMode              `json:"subscription_auth_mode"`
@@ -67,14 +67,14 @@ func NewDefaultPolicies() *Policies {
 		PublishMaxMessageRate:       make(map[string]PublishRate),
 		ClusterSubscribeRate:        make(map[string]SubscribeRate),
 		LatencyStatsSampleRate:      make(map[string]int),
-		MessageTTLInSeconds:         0,
+		MessageTTLInSeconds:         nil,
 		Deleted:                     false,
 		EncryptionRequired:          false,
 		SubscriptionAuthMode:        None,
-		MaxProducersPerTopic:        0,
-		MaxConsumersPerSubscription: 0,
-		MaxConsumersPerTopic:        0,
-		CompactionThreshold:         0,
+		MaxProducersPerTopic:        nil,
+		MaxConsumersPerSubscription: nil,
+		MaxConsumersPerTopic:        nil,
+		CompactionThreshold:         nil,
 		OffloadThreshold:            -1,
 		SchemaCompatibilityStrategy: Full,
 		SchemaValidationEnforced:    false,


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

Use correct type in namespace policies, when the type is not correct, it will override the Pulsar broker config.