### PR TITLE
ci: disable cgo

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -22,6 +22,9 @@ function checkFunctionWorker() {
 pushd ${PULSARCTL_HOME}
 # startup pulsar service
 scripts/pulsar-service-startup.sh
+
+# disable cgo
+export CGO_ENABLED=0
 # run tests
 case ${TEST_ARGS} in
     token)


### PR DESCRIPTION
### Motivation
The go enables cgo by default, and requires gcc, but the gcc not found in `streamnative/pulsar-all:2.10.0.0-rc2`, and blocks the branch-2.10.0.0 release, so we need to disable the cgo before test. 

Fail log:
```
go: finding github.com/mitchellh/go-homedir v1.1.0
go: finding golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93
go: finding github.com/mtibben/percent v0.2.1
go: finding golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
go: finding golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d
# runtime/cgo
exec: "gcc": executable file not found in $PATH
FAIL	command-line-arguments [build failed]
FAIL
Error: Process completed with exit code 2.
```