### PR TITLE
fix: fix encode json body

### DIFF
--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -364,12 +364,11 @@ func endpoint(parts ...string) string {
 
 // encodeJSONBody is used to JSON encode a body
 func encodeJSONBody(obj interface{}) (io.Reader, error) {
-	buf := bytes.NewBuffer(nil)
-	enc := json.NewEncoder(buf)
-	if err := enc.Encode(obj); err != nil {
+	b, err := json.Marshal(obj)
+	if err != nil {
 		return nil, err
 	}
-	return buf, nil
+	return bytes.NewReader(b), nil
 }
 
 // decodeJSONBody is used to JSON decode a body

--- a/pkg/cli/client_test.go
+++ b/pkg/cli/client_test.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package cli
 
 import (

--- a/pkg/cli/client_test.go
+++ b/pkg/cli/client_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeJSONBody(t *testing.T) {
+	testcases := []struct {
+		obj      interface{}
+		expected int
+	}{
+		{obj: "1", expected: 3},
+		{obj: "12", expected: 4},
+		{obj: 1, expected: 1},
+		{obj: 12, expected: 2},
+	}
+
+	for _, testcase := range testcases {
+		r, err := encodeJSONBody(testcase.obj)
+		require.NoError(t, err)
+
+		b, err := ioutil.ReadAll(r)
+		require.NoError(t, err)
+
+		require.Equal(t, testcase.expected, len(b))
+	}
+}

--- a/pkg/ctl/namespace/get_ns_anti_affinity_group.go
+++ b/pkg/ctl/namespace/get_ns_anti_affinity_group.go
@@ -76,7 +76,7 @@ func doGetAntiAffinityGroup(vc *cmdutils.VerbCmd) error {
 	admin := cmdutils.NewPulsarClient()
 	res, err := admin.Namespaces().GetNamespaceAntiAffinityGroup(ns)
 	if err == nil {
-		vc.Command.Print(res)
+		vc.Command.Println(res)
 	}
 	return err
 }

--- a/pkg/ctl/namespace/ns_anti_affinity_test.go
+++ b/pkg/ctl/namespace/ns_anti_affinity_test.go
@@ -47,5 +47,5 @@ func TestNsAntiAffinityGroup(t *testing.T) {
 	getArgs = []string{"get-anti-affinity-group", "public/test-anti-namespace"}
 	getOut, execErr, _, _ = TestNamespaceCommands(getAntiAffinityGroup, getArgs)
 	assert.Nil(t, execErr)
-	assert.Equal(t, getOut.String(), "")
+	assert.Equal(t, getOut.String(), "\n")
 }


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Summary

Use `json.Marshal()` instead of `json.NewEncoder().Encode()` to encode JSON, because the `json.NewEncoder().Encode()` appends a newline character in end of body, sometimes the JAVA cannot parse this body.