### PR TITLE
ci: use root

### DIFF
--- a/scripts/test-docker/Dockerfile
+++ b/scripts/test-docker/Dockerfile
@@ -1,6 +1,9 @@
 ARG PULSAR_VERSION
 FROM streamnative/pulsar-all:$PULSAR_VERSION
 
+# use root user
+USER root
+
 # install golang
 ENV GOLANG_VERSION 1.13.3
 RUN curl -sSL https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd64.tar.gz \


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

Fix https://github.com/streamnative/pulsarctl/pull/616

### Summary

The pulsar image default to run as the non-root user, this changed by https://github.com/apache/pulsar/pull/13376.
