### PR TITLE
fix: use nil instead of empty string as request body

### DIFF
--- a/pkg/pulsar/functions.go
+++ b/pkg/pulsar/functions.go
@@ -266,14 +266,14 @@ func (f *functions) CreateFuncWithURL(funcConf *utils.FunctionConfig, pkgURL str
 
 func (f *functions) StopFunction(tenant, namespace, name string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name)
-	return f.pulsar.Client.Post(endpoint+"/stop", "")
+	return f.pulsar.Client.Post(endpoint+"/stop", nil)
 }
 
 func (f *functions) StopFunctionWithID(tenant, namespace, name string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, id)
 
-	return f.pulsar.Client.Post(endpoint+"/stop", "")
+	return f.pulsar.Client.Post(endpoint+"/stop", nil)
 }
 
 func (f *functions) DeleteFunction(tenant, namespace, name string) error {
@@ -329,26 +329,26 @@ func (f *functions) DownloadFunctionByNs(destinationFile, tenant, namespace, fun
 
 func (f *functions) StartFunction(tenant, namespace, name string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name)
-	return f.pulsar.Client.Post(endpoint+"/start", "")
+	return f.pulsar.Client.Post(endpoint+"/start", nil)
 }
 
 func (f *functions) StartFunctionWithID(tenant, namespace, name string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, id)
 
-	return f.pulsar.Client.Post(endpoint+"/start", "")
+	return f.pulsar.Client.Post(endpoint+"/start", nil)
 }
 
 func (f *functions) RestartFunction(tenant, namespace, name string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name)
-	return f.pulsar.Client.Post(endpoint+"/restart", "")
+	return f.pulsar.Client.Post(endpoint+"/restart", nil)
 }
 
 func (f *functions) RestartFunctionWithID(tenant, namespace, name string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, id)
 
-	return f.pulsar.Client.Post(endpoint+"/restart", "")
+	return f.pulsar.Client.Post(endpoint+"/restart", nil)
 }
 
 func (f *functions) GetFunctions(tenant, namespace string) ([]string, error) {

--- a/pkg/pulsar/namespace.go
+++ b/pkg/pulsar/namespace.go
@@ -678,7 +678,7 @@ func (n *namespaces) Unload(namespace string) error {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "unload")
-	return n.pulsar.Client.Put(endpoint, "")
+	return n.pulsar.Client.Put(endpoint, nil)
 }
 
 func (n *namespaces) UnloadNamespaceBundle(namespace, bundle string) error {
@@ -687,7 +687,7 @@ func (n *namespaces) UnloadNamespaceBundle(namespace, bundle string) error {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), bundle, "unload")
-	return n.pulsar.Client.Put(endpoint, "")
+	return n.pulsar.Client.Put(endpoint, nil)
 }
 
 func (n *namespaces) SplitNamespaceBundle(namespace, bundle string, unloadSplitBundles bool) error {
@@ -699,7 +699,7 @@ func (n *namespaces) SplitNamespaceBundle(namespace, bundle string, unloadSplitB
 	params := map[string]string{
 		"unload": strconv.FormatBool(unloadSplitBundles),
 	}
-	return n.pulsar.Client.PutWithQueryParams(endpoint, "", nil, params)
+	return n.pulsar.Client.PutWithQueryParams(endpoint, nil, nil, params)
 }
 
 func (n *namespaces) GetNamespacePermissions(namespace utils.NameSpaceName) (map[string][]common.AuthAction, error) {
@@ -748,33 +748,33 @@ func (n *namespaces) SetEncryptionRequiredStatus(namespace utils.NameSpaceName, 
 
 func (n *namespaces) UnsubscribeNamespace(namespace utils.NameSpaceName, sName string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "unsubscribe", url.QueryEscape(sName))
-	return n.pulsar.Client.Post(endpoint, "")
+	return n.pulsar.Client.Post(endpoint, nil)
 }
 
 func (n *namespaces) UnsubscribeNamespaceBundle(namespace utils.NameSpaceName, bundle, sName string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), bundle, "unsubscribe", url.QueryEscape(sName))
-	return n.pulsar.Client.Post(endpoint, "")
+	return n.pulsar.Client.Post(endpoint, nil)
 }
 
 func (n *namespaces) ClearNamespaceBundleBacklogForSubscription(namespace utils.NameSpaceName,
 	bundle, sName string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), bundle, "clearBacklog", url.QueryEscape(sName))
-	return n.pulsar.Client.Post(endpoint, "")
+	return n.pulsar.Client.Post(endpoint, nil)
 }
 
 func (n *namespaces) ClearNamespaceBundleBacklog(namespace utils.NameSpaceName, bundle string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), bundle, "clearBacklog")
-	return n.pulsar.Client.Post(endpoint, "")
+	return n.pulsar.Client.Post(endpoint, nil)
 }
 
 func (n *namespaces) ClearNamespaceBacklogForSubscription(namespace utils.NameSpaceName, sName string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "clearBacklog", url.QueryEscape(sName))
-	return n.pulsar.Client.Post(endpoint, "")
+	return n.pulsar.Client.Post(endpoint, nil)
 }
 
 func (n *namespaces) ClearNamespaceBacklog(namespace utils.NameSpaceName) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "clearBacklog")
-	return n.pulsar.Client.Post(endpoint, "")
+	return n.pulsar.Client.Post(endpoint, nil)
 }
 
 func (n *namespaces) SetReplicatorDispatchRate(namespace utils.NameSpaceName, rate utils.DispatchRate) error {

--- a/pkg/pulsar/sinks.go
+++ b/pkg/pulsar/sinks.go
@@ -390,38 +390,38 @@ func (s *sinks) GetSinkStatusWithID(tenant, namespace, sink string, id int) (uti
 
 func (s *sinks) RestartSink(tenant, namespace, sink string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink)
-	return s.pulsar.Client.Post(endpoint+"/restart", "")
+	return s.pulsar.Client.Post(endpoint+"/restart", nil)
 }
 
 func (s *sinks) RestartSinkWithID(tenant, namespace, sink string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink, id)
 
-	return s.pulsar.Client.Post(endpoint+"/restart", "")
+	return s.pulsar.Client.Post(endpoint+"/restart", nil)
 }
 
 func (s *sinks) StopSink(tenant, namespace, sink string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink)
-	return s.pulsar.Client.Post(endpoint+"/stop", "")
+	return s.pulsar.Client.Post(endpoint+"/stop", nil)
 }
 
 func (s *sinks) StopSinkWithID(tenant, namespace, sink string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink, id)
 
-	return s.pulsar.Client.Post(endpoint+"/stop", "")
+	return s.pulsar.Client.Post(endpoint+"/stop", nil)
 }
 
 func (s *sinks) StartSink(tenant, namespace, sink string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink)
-	return s.pulsar.Client.Post(endpoint+"/start", "")
+	return s.pulsar.Client.Post(endpoint+"/start", nil)
 }
 
 func (s *sinks) StartSinkWithID(tenant, namespace, sink string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink, id)
 
-	return s.pulsar.Client.Post(endpoint+"/start", "")
+	return s.pulsar.Client.Post(endpoint+"/start", nil)
 }
 
 func (s *sinks) GetBuiltInSinks() ([]*utils.ConnectorDefinition, error) {
@@ -433,5 +433,5 @@ func (s *sinks) GetBuiltInSinks() ([]*utils.ConnectorDefinition, error) {
 
 func (s *sinks) ReloadBuiltInSinks() error {
 	endpoint := s.pulsar.endpoint(s.basePath, "reloadBuiltInSinks")
-	return s.pulsar.Client.Post(endpoint, "")
+	return s.pulsar.Client.Post(endpoint, nil)
 }

--- a/pkg/pulsar/sources.go
+++ b/pkg/pulsar/sources.go
@@ -393,38 +393,38 @@ func (s *sources) GetSourceStatusWithID(tenant, namespace, source string, id int
 
 func (s *sources) RestartSource(tenant, namespace, source string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source)
-	return s.pulsar.Client.Post(endpoint+"/restart", "")
+	return s.pulsar.Client.Post(endpoint+"/restart", nil)
 }
 
 func (s *sources) RestartSourceWithID(tenant, namespace, source string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source, id)
 
-	return s.pulsar.Client.Post(endpoint+"/restart", "")
+	return s.pulsar.Client.Post(endpoint+"/restart", nil)
 }
 
 func (s *sources) StopSource(tenant, namespace, source string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source)
-	return s.pulsar.Client.Post(endpoint+"/stop", "")
+	return s.pulsar.Client.Post(endpoint+"/stop", nil)
 }
 
 func (s *sources) StopSourceWithID(tenant, namespace, source string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source, id)
 
-	return s.pulsar.Client.Post(endpoint+"/stop", "")
+	return s.pulsar.Client.Post(endpoint+"/stop", nil)
 }
 
 func (s *sources) StartSource(tenant, namespace, source string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source)
-	return s.pulsar.Client.Post(endpoint+"/start", "")
+	return s.pulsar.Client.Post(endpoint+"/start", nil)
 }
 
 func (s *sources) StartSourceWithID(tenant, namespace, source string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source, id)
 
-	return s.pulsar.Client.Post(endpoint+"/start", "")
+	return s.pulsar.Client.Post(endpoint+"/start", nil)
 }
 
 func (s *sources) GetBuiltInSources() ([]*utils.ConnectorDefinition, error) {
@@ -436,5 +436,5 @@ func (s *sources) GetBuiltInSources() ([]*utils.ConnectorDefinition, error) {
 
 func (s *sources) ReloadBuiltInSources() error {
 	endpoint := s.pulsar.endpoint(s.basePath, "reloadBuiltInSources")
-	return s.pulsar.Client.Post(endpoint, "")
+	return s.pulsar.Client.Post(endpoint, nil)
 }

--- a/pkg/pulsar/subscription.go
+++ b/pkg/pulsar/subscription.go
@@ -111,34 +111,34 @@ func (s *subscriptions) ResetCursorToTimestamp(topic utils.TopicName, sName stri
 	endpoint := s.pulsar.endpoint(
 		s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName),
 		"resetcursor", strconv.FormatInt(timestamp, 10))
-	return s.pulsar.Client.Post(endpoint, "")
+	return s.pulsar.Client.Post(endpoint, nil)
 }
 
 func (s *subscriptions) ClearBacklog(topic utils.TopicName, sName string) error {
 	endpoint := s.pulsar.endpoint(
 		s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName), "skip_all")
-	return s.pulsar.Client.Post(endpoint, "")
+	return s.pulsar.Client.Post(endpoint, nil)
 }
 
 func (s *subscriptions) SkipMessages(topic utils.TopicName, sName string, n int64) error {
 	endpoint := s.pulsar.endpoint(
 		s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName),
 		"skip", strconv.FormatInt(n, 10))
-	return s.pulsar.Client.Post(endpoint, "")
+	return s.pulsar.Client.Post(endpoint, nil)
 }
 
 func (s *subscriptions) ExpireMessages(topic utils.TopicName, sName string, expire int64) error {
 	endpoint := s.pulsar.endpoint(
 		s.basePath, topic.GetRestPath(), s.SubPath, url.PathEscape(sName),
 		"expireMessages", strconv.FormatInt(expire, 10))
-	return s.pulsar.Client.Post(endpoint, "")
+	return s.pulsar.Client.Post(endpoint, nil)
 }
 
 func (s *subscriptions) ExpireAllMessages(topic utils.TopicName, expire int64) error {
 	endpoint := s.pulsar.endpoint(
 		s.basePath, topic.GetRestPath(), "all_subscription",
 		"expireMessages", strconv.FormatInt(expire, 10))
-	return s.pulsar.Client.Post(endpoint, "")
+	return s.pulsar.Client.Post(endpoint, nil)
 }
 
 func (s *subscriptions) PeekMessages(topic utils.TopicName, sName string, n int) ([]*utils.Message, error) {

--- a/pkg/pulsar/topic.go
+++ b/pkg/pulsar/topic.go
@@ -401,7 +401,7 @@ func (t *topics) GetPartitionedStats(topic utils.TopicName, perPartition bool) (
 func (t *topics) Terminate(topic utils.TopicName) (utils.MessageID, error) {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "terminate")
 	var messageID utils.MessageID
-	err := t.pulsar.Client.PostWithObj(endpoint, "", &messageID)
+	err := t.pulsar.Client.PostWithObj(endpoint, nil, &messageID)
 	return messageID, err
 }
 
@@ -419,12 +419,12 @@ func (t *topics) OffloadStatus(topic utils.TopicName) (utils.OffloadProcessStatu
 
 func (t *topics) Unload(topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "unload")
-	return t.pulsar.Client.Put(endpoint, "")
+	return t.pulsar.Client.Put(endpoint, nil)
 }
 
 func (t *topics) Compact(topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "compaction")
-	return t.pulsar.Client.Put(endpoint, "")
+	return t.pulsar.Client.Put(endpoint, nil)
 }
 
 func (t *topics) CompactStatus(topic utils.TopicName) (utils.LongRunningProcessStatus, error) {


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

The empty string does not equal the `nil`, if we don't need to pass the request body, we need to use the `nil`.

### Modifications

- Use `nil` instead of `""`

### Documentation

- [x] `no-need-doc` 


