### PR TITLE
fix: skip fix_mac_openssl for non-mac os in pulsarctl-security_tool

### DIFF
--- a/plugins/pulsarctl-security_tool
+++ b/plugins/pulsarctl-security_tool
@@ -403,7 +403,9 @@ function ensure_dependencies() {
     fi
   done
   # fix open ssl if needed
-  fix_mac_openssl
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    fix_mac_openssl
+  fi
 }
 
 # if no args specified, show usage


### PR DESCRIPTION
### Motivation

Current plugin security_tool introduced `fix_mac_openssl` to fix openssl  compatibility issue under Mac OS, but it does not check if the command is under non-Mac OS, which failed running under those situations. 

### Modifications

*Describe the modifications you've done.*

Just check if the `OSTYPE` matches `darwin`, skip `fix_mac_openssl` if not.
