### PR TITLE
Add the update-auth data option to sink update and sources update

### DIFF
--- a/pkg/ctl/sinks/update.go
+++ b/pkg/ctl/sinks/update.go
@@ -249,6 +249,12 @@ func updateSinksCmd(vc *cmdutils.VerbCmd) {
 			"timeout-ms",
 			0,
 			"The message timeout in milliseconds")
+
+		flagSet.BoolVar(
+			&functionData.UpdateAuthData,
+			"update-auth-data",
+			false,
+			"Whether or not to update the auth data")
 	})
 	vc.EnableOutputFlagSet()
 }

--- a/pkg/ctl/sinks/update.go
+++ b/pkg/ctl/sinks/update.go
@@ -251,7 +251,7 @@ func updateSinksCmd(vc *cmdutils.VerbCmd) {
 			"The message timeout in milliseconds")
 
 		flagSet.BoolVar(
-			&functionData.UpdateAuthData,
+			&sinkData.UpdateAuthData,
 			"update-auth-data",
 			false,
 			"Whether or not to update the auth data")

--- a/pkg/ctl/sources/update.go
+++ b/pkg/ctl/sources/update.go
@@ -209,6 +209,12 @@ func updateSourcesCmd(vc *cmdutils.VerbCmd) {
 			"source-config",
 			"",
 			"Source config key/values")
+
+		flagSet.BoolVar(
+			&functionData.UpdateAuthData,
+			"update-auth-data",
+			false,
+			"Whether or not to update the auth data")
 	})
 }
 

--- a/pkg/ctl/sources/update.go
+++ b/pkg/ctl/sources/update.go
@@ -211,7 +211,7 @@ func updateSourcesCmd(vc *cmdutils.VerbCmd) {
 			"Source config key/values")
 
 		flagSet.BoolVar(
-			&functionData.UpdateAuthData,
+			&sourceData.UpdateAuthData,
 			"update-auth-data",
 			false,
 			"Whether or not to update the auth data")


### PR DESCRIPTION

Fixes #726

### Motivation

make pulsarctl update auth in sinks and sources as it does with functions

### Modifications

Add the option to take the variable.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

Need to update docs? 

- [X ] `doc-required` 
  
  The documentation needs to reflect this change
