### PR TITLE
fix: fix tls insecure connection

### DIFF
--- a/pkg/auth/auth_provider.go
+++ b/pkg/auth/auth_provider.go
@@ -37,7 +37,7 @@ type Transport struct {
 	T http.RoundTripper
 }
 
-func GetAuthProvider(config *common.Config) (*Provider, error) {
+func GetAuthProvider(config *common.Config) (Provider, error) {
 	var provider Provider
 	defaultTransport, err := NewDefaultTransport(config)
 	if err != nil {
@@ -65,7 +65,7 @@ func GetAuthProvider(config *common.Config) (*Provider, error) {
 				config.IssuerEndpoint, config.ClientID, config.Audience, config.Scope, defaultTransport)
 		}
 	}
-	return &provider, err
+	return provider, err
 }
 
 // GetDefaultTransport gets a default transport.

--- a/pkg/pulsar/admin_test.go
+++ b/pkg/pulsar/admin_test.go
@@ -18,11 +18,13 @@
 package pulsar
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/streamnative/pulsarctl/pkg/auth"
 	"github.com/streamnative/pulsarctl/pkg/pulsar/common"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPulsarClientEndpointEscapes(t *testing.T) {
@@ -30,4 +32,75 @@ func TestPulsarClientEndpointEscapes(t *testing.T) {
 	actual := client.endpoint("/myendpoint", "abc%? /def", "ghi")
 	expected := "/admin/v2/myendpoint/abc%25%3F%20%2Fdef/ghi"
 	assert.Equal(t, expected, actual)
+}
+
+func TestNew(t *testing.T) {
+	config := &common.Config{}
+	admin, err := New(config)
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+}
+
+func TestNewWithAuthProvider(t *testing.T) {
+	config := &common.Config{}
+
+	tokenAuth, err := auth.NewAuthenticationToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."+
+		"eyJzdWIiOiJhZG1pbiIsImlhdCI6MTUxNjIzOTAyMn0.sVt6cyu3HKd89LcQvZVMNbqT0DTl3FvG9oYbj8hBDqU", nil)
+	require.NoError(t, err)
+	require.NotNil(t, tokenAuth)
+
+	admin, err := NewPulsarClientWithAuthProvider(config, tokenAuth)
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+}
+
+type customAuthProvider struct {
+	transport http.RoundTripper
+}
+
+var _ auth.Provider = &customAuthProvider{}
+
+func (c *customAuthProvider) RoundTrip(req *http.Request) (*http.Response, error) {
+	panic("implement me")
+}
+
+func (c *customAuthProvider) Transport() http.RoundTripper {
+	return c.transport
+}
+
+func (c *customAuthProvider) WithTransport(transport http.RoundTripper) {
+	c.transport = transport
+}
+
+func TestNewWithCustomAuthProviderWithTransport(t *testing.T) {
+	config := &common.Config{}
+	defaultTransport, err := auth.NewDefaultTransport(config)
+	require.NoError(t, err)
+
+	customAuthProvider := &customAuthProvider{
+		transport: defaultTransport,
+	}
+
+	admin, err := NewPulsarClientWithAuthProvider(config, customAuthProvider)
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+
+	// Expected the transport of customAuthProvider will not be overwritten.
+	require.Equal(t, defaultTransport, admin.(*pulsarClient).Client.HTTPClient.Transport)
+}
+
+func TestNewWithTlsAllowInsecure(t *testing.T) {
+	config := &common.Config{
+		TLSAllowInsecureConnection: true,
+	}
+	admin, err := New(config)
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+
+	pulsarClientS := admin.(*pulsarClient)
+	require.NotNil(t, pulsarClientS.Client.HTTPClient.Transport)
+	tr := pulsarClientS.Client.HTTPClient.Transport.(*http.Transport)
+	require.NotNil(t, tr)
+	require.NotNil(t, tr.TLSClientConfig)
+	require.True(t, tr.TLSClientConfig.InsecureSkipVerify)
 }

--- a/pkg/pulsar/utils/utils_test.go
+++ b/pkg/pulsar/utils/utils_test.go
@@ -58,4 +58,10 @@ func TestIsNilFixed(t *testing.T) {
 
 	var ch chan string
 	assert.True(t, IsNilFixed(ch))
+
+	var nilInterface People
+	assert.True(t, IsNilFixed(nilInterface))
+
+	// pointer to an interface, the IsNilFixed method cannot check this.
+	assert.False(t, IsNilFixed(&nilInterface))
 }


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

The tls insecure connection config doesn't work.

The root cause is the `TLSAllowInsecureConnection` config is ignored when the `AuthPlugin` is not configured.

### Modifications

- Fix `auth.GetAuthProvider()` return type, avoid returns a pointer to an interface, the `utils.IsNilFixed()` cannot check this value
- Improve creating the Pulsar client
  - The `pulsar.New()` method calls the `pulsar.NewPulsarClientWithAuthProvider` to create a instance
  - Fix tls config when no auth provider
  - Fix inject the transport
    - If there is no auth provider, the default transport is used
    - If there is an auth provider with transport, the transport from auth provider is used, otherwise the default transport is used

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  

