### PR TITLE
Fix test new with custom auth provider

### DIFF
--- a/pkg/pulsar/admin_test.go
+++ b/pkg/pulsar/admin_test.go
@@ -85,8 +85,8 @@ func TestNewWithCustomAuthProviderWithTransport(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, admin)
 
-	// Expected the transport of customAuthProvider will not be overwritten.
-	require.Equal(t, defaultTransport, admin.(*pulsarClient).Client.HTTPClient.Transport)
+	// Expected the customAuthProvider will not be overwritten.
+	require.Equal(t, customAuthProvider, admin.(*pulsarClient).Client.HTTPClient.Transport)
 }
 
 func TestNewWithTlsAllowInsecure(t *testing.T) {

--- a/scripts/test-docker/Dockerfile
+++ b/scripts/test-docker/Dockerfile
@@ -10,6 +10,10 @@ RUN curl -sSL https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd6
 		| tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
+# install git
+RUN apt update
+RUN apt install git -y
+
 # copy the code into image
 COPY . /pulsarctl
 


### PR DESCRIPTION
### Motivation

Test fails.

### Modifications

- Fix `TestNewWithCustomAuthProviderWithTransport` test
- Test broken, see https://github.com/streamnative/pulsarctl/runs/6753134246?check_suite_focus=true#step:3:158, fix test image

### Documentation

- [x] `no-need-doc` 

