### PR TITLE
[feature] Set/get topic schema compatibility strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The following is an incomplete list of features that are not yet implemented:
 
 ## Different With Java Pulsar Admin
 
-We move the subscription commands from the topics to the subscriptions in pulsarctl.
+Subscription commands have moved from the `topics` category to the `subscriptions` category in `pulsarctl`.
  
 | pulsar-admin | pulsarctl |
 | ------------ | --------- |
@@ -172,6 +172,13 @@ We move the subscription commands from the topics to the subscriptions in pulsar
 | bin/pulsar-admin topics peek-messages | pulsarctl subscription peek |
 | bin/pulsar-admin topics reset-cursor | pulsarctl subscription seek |
 | bin/pulsar-admin topics subscriptions | pulsarctl subscription list |
+
+Topic schema compatibility commands have moved from the `topicPolicies` category to the `topic` category in `pulsarctl`.
+ 
+| pulsar-admin | pulsarctl |
+| ------------ | --------- |
+| bin/pulsar-admin topicPolicies set-schema-compatibility-strategy | pulsarctl topic set-schema-compatibility-strategy |
+| bin/pulsar-admin topicPolicies get-schema-compatibility-strategy | pulsarctl topic get-schema-compatibility-strategy |
 
 ## Contribute
 


### PR DESCRIPTION
Fixes #783

### Motivation

`pulsarctl` cannot be used to set topic level schema compatibility strategies.

### Modifications

Added get/set commands for topic.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.
* I would argue that there should be tests for this and similar functionality, however currently there are none.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
- [ ] `no-need-doc` 
  
- [x] `doc` 
    * Note: These specific commands were erroneously not listed in the [Project status](https://github.com/streamnative/pulsarctl#project-status) section of the README.
    * Added section on differences with `pulsar-admin`.

