### PR TITLE
fix: Remove encoding for the topic

### DIFF
--- a/pkg/ctl/topic/create_test.go
+++ b/pkg/ctl/topic/create_test.go
@@ -20,6 +20,7 @@ package topic
 import (
 	"testing"
 
+	"github.com/streamnative/pulsarctl/pkg/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,6 +79,31 @@ func TestCreateNonPartitionedTopic(t *testing.T) {
 func TestCreateNonPersistentNonPartitionedTopic(t *testing.T) {
 	args := []string{"create", "non-persistent://public/default/test-create-non-partitioned-topic", "0"}
 	_, execErr, argsErr, err := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+	assert.Nil(t, argsErr)
+	assert.Nil(t, err)
+}
+
+func TestCreateTopicNameWithColons(t *testing.T) {
+	topic := "persistent://public/default/test:topic-" + test.RandomSuffix()
+	args := []string{"create", topic, "0"}
+	_, execErr, argsErr, err := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+	assert.Nil(t, argsErr)
+	assert.Nil(t, err)
+
+}
+
+func TestCreateTopicNameWithEncodedColons(t *testing.T) {
+	topic := "persistent://public/default/test%3Atopic-" + test.RandomSuffix()
+	args := []string{"create", topic, "0"}
+	_, execErr, argsErr, err := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+	assert.Nil(t, argsErr)
+	assert.Nil(t, err)
+
+	args = []string{"get", topic}
+	_, execErr, argsErr, err = TestTopicCommands(GetTopicCmd, args)
 	assert.Nil(t, execErr)
 	assert.Nil(t, argsErr)
 	assert.Nil(t, err)

--- a/pkg/pulsar/schema.go
+++ b/pkg/pulsar/schema.go
@@ -62,7 +62,7 @@ func (s *schemas) GetSchemaInfo(topic string) (*utils.SchemaInfo, error) {
 	}
 	var response utils.GetSchemaResponse
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
-		topicName.GetEncodedTopic(), "schema")
+		topicName.GetLocalName(), "schema")
 
 	err = s.pulsar.Client.Get(endpoint, &response)
 	if err != nil {
@@ -80,7 +80,7 @@ func (s *schemas) GetSchemaInfoWithVersion(topic string) (*utils.SchemaInfoWithV
 	}
 	var response utils.GetSchemaResponse
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
-		topicName.GetEncodedTopic(), "schema")
+		topicName.GetLocalName(), "schema")
 
 	err = s.pulsar.Client.Get(endpoint, &response)
 	if err != nil {
@@ -99,7 +99,7 @@ func (s *schemas) GetSchemaInfoByVersion(topic string, version int64) (*utils.Sc
 	}
 
 	var response utils.GetSchemaResponse
-	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(), topicName.GetEncodedTopic(),
+	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(), topicName.GetLocalName(),
 		"schema", strconv.FormatInt(version, 10))
 
 	err = s.pulsar.Client.Get(endpoint, &response)
@@ -118,7 +118,7 @@ func (s *schemas) DeleteSchema(topic string) error {
 	}
 
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
-		topicName.GetEncodedTopic(), "schema")
+		topicName.GetLocalName(), "schema")
 
 	fmt.Println(endpoint)
 
@@ -132,7 +132,7 @@ func (s *schemas) CreateSchemaByPayload(topic string, schemaPayload utils.PostSc
 	}
 
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
-		topicName.GetEncodedTopic(), "schema")
+		topicName.GetLocalName(), "schema")
 
 	return s.pulsar.Client.Post(endpoint, &schemaPayload)
 }

--- a/pkg/pulsar/utils/topic_name.go
+++ b/pkg/pulsar/utils/topic_name.go
@@ -119,7 +119,7 @@ func (t *TopicName) IsPersistent() bool {
 }
 
 func (t *TopicName) GetRestPath() string {
-	return fmt.Sprintf("%s/%s/%s/%s", t.domain, t.tenant, t.namespace, t.GetEncodedTopic())
+	return fmt.Sprintf("%s/%s/%s/%s", t.domain, t.tenant, t.namespace, t.topic)
 }
 
 func (t *TopicName) GetEncodedTopic() string {

--- a/pkg/pulsar/utils/topic_name_test.go
+++ b/pkg/pulsar/utils/topic_name_test.go
@@ -18,7 +18,6 @@
 package utils
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,21 +72,4 @@ func TestGetTopicName(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, "topic name can not be empty", err.Error())
 	assert.Nil(t, fail)
-}
-
-func TestTopicNameEncodeTest(t *testing.T) {
-	encodedName := "a%3Aen-in_in_business_content_item_20150312173022_https%5C%3A%2F%2Fin.news.example.com%2Fr"
-	rawName := "a:en-in_in_business_content_item_20150312173022_https\\://in.news.example.com/r"
-
-	assert.Equal(t, encodedName, url.QueryEscape(rawName))
-	o, err := url.QueryUnescape(encodedName)
-	assert.Nil(t, err)
-	assert.Equal(t, rawName, o)
-
-	topicName, err := GetTopicName("persistent://prop/ns/" + rawName)
-	assert.Nil(t, err)
-
-	assert.Equal(t, rawName, topicName.topic)
-	assert.Equal(t, encodedName, topicName.GetEncodedTopic())
-	assert.Equal(t, "persistent/prop/ns/"+encodedName, topicName.GetRestPath())
 }


### PR DESCRIPTION
Fix #827.

### Motivation

Topic names are encoded multiple times.

Pulsarctl:
```
pulsarctl topics create persistent://public/default/topic:12 0
```

Broker log:
```
2022-09-12T23:43:46,027+0800 [broker-topic-workers-OrderedExecutor-0-0] INFO  org.apache.pulsar.broker.admin.impl.PersistentTopicsBase - [null] Successfully created non-partitioned topic persistent://public/default/topic%3A12
2022-09-12T23:43:46,028+0800 [broker-topic-workers-OrderedExecutor-0-0] INFO  org.eclipse.jetty.server.RequestLog - 127.0.0.1 - - [12/9月/2022:23:43:45 +0800] "PUT /admi/v2/persistent/public/default/topic%253A12 HTTP/1.1" 204 0 "-" "None" 103
```

Expected log:
```
2022-09-12T23:44:36,554+0800 [broker-topic-workers-OrderedExecutor-7-0] INFO  org.apache.pulsar.broker.admin.impl.PersistentTopicsBase - [null] Successfully created non-partitioned topic persistent://public/default/topic:12
2022-09-12T23:44:36,555+0800 [broker-topic-workers-OrderedExecutor-7-0] INFO  org.eclipse.jetty.server.RequestLog - 127.0.0.1 - - [12/9月/2022:23:44:36 +0800] "PUT /admi/v2/persistent/public/default/topic:12 HTTP/1.1" 204 0 "-" "None" 111
```

### Modifications

Remove the `GetEncodedTopic()` method.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

