### PR TITLE
test: fix get internal config test

### DIFF
--- a/pkg/ctl/brokers/config_test.go
+++ b/pkg/ctl/brokers/config_test.go
@@ -33,10 +33,6 @@ func TestGetInternalConfig(t *testing.T) {
 	var internalData utils.InternalConfigurationData
 	err := json.Unmarshal(internalOut.Bytes(), &internalData)
 	assert.Nil(t, err)
-
-	assert.Equal(t, "127.0.0.1:2181", internalData.ZookeeperServers)
-	assert.Equal(t, "127.0.0.1:2181", internalData.ConfigurationStoreServers)
-	assert.Equal(t, "/ledgers", internalData.LedgersRootPath)
 }
 
 func TestGetRuntimeConfig(t *testing.T) {


### PR DESCRIPTION
### Motivation

GetInternalConfig doesn't include the zk config on the Pulsar standalone.

### Modifications

- Remove the check response value on the test

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

