### PR TITLE
fix: upgrade the alpine to fix CVE-2022-37434

### DIFF
--- a/docker/amd64-linux.Dockerfile
+++ b/docker/amd64-linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.0
+FROM alpine:3.16.2
 
 ADD pulsarctl /usr/local/bin/pulsarctl
 


### PR DESCRIPTION

Fixes #823 

### Motivation

 Fix CVE-2022-37434.

### Modifications

Upgrade the alpine from 3.16.0 to 3.16.0

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

