### PR TITLE
add fields to topic stats

### DIFF
--- a/pkg/pulsar/utils/data.go
+++ b/pkg/pulsar/utils/data.go
@@ -183,6 +183,8 @@ type NamespacesData struct {
 }
 
 type TopicStats struct {
+	MsgCounterIn        int64                        `json:"msgInCounter"`
+	MsgCounterOut       int64                        `json:"msgOutCounter"`
 	MsgRateIn           float64                      `json:"msgRateIn"`
 	MsgRateOut          float64                      `json:"msgRateOut"`
 	MsgThroughputIn     float64                      `json:"msgThroughputIn"`
@@ -206,11 +208,15 @@ type PublisherStats struct {
 type SubscriptionStats struct {
 	BlockedSubscriptionOnUnackedMsgs bool            `json:"blockedSubscriptionOnUnackedMsgs"`
 	IsReplicated                     bool            `json:"isReplicated"`
+	LastConsumedFlowTimestamp        int64           `json:"lastConsumedFlowTimestamp"`
+	LastConsumedTimestamp            int64           `json:"lastConsumedTimestamp"`
+	LastAckedTimestamp               int64           `json:"lastAckedTimestamp"`
 	MsgRateOut                       float64         `json:"msgRateOut"`
 	MsgThroughputOut                 float64         `json:"msgThroughputOut"`
 	MsgRateRedeliver                 float64         `json:"msgRateRedeliver"`
 	MsgRateExpired                   float64         `json:"msgRateExpired"`
 	MsgBacklog                       int64           `json:"msgBacklog"`
+	MsgBacklogNoDelayed              int64           `json:"msgBacklogNoDelayed"`
 	MsgDelayed                       int64           `json:"msgDelayed"`
 	UnAckedMessages                  int64           `json:"unackedMessages"`
 	SubType                          string          `json:"type"`


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

The Pulsar admin API is returning a lot of fields that pulsarctl does not report. As a temporary fix I would like to add several fields related to:

* Counting overall messages in and out of a topic
* Reporting the last consumed and acked times
* Reporting no delay messages specifically

### Modifications

Add the necessary fields to the `TopicStats` and `SubscriptionStats` structs. I have tested this against a running pulsar deployment.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

