### PR TITLE
fix: fix update sink

### DIFF
--- a/pkg/ctl/sinks/update.go
+++ b/pkg/ctl/sinks/update.go
@@ -255,6 +255,10 @@ func updateSinksCmd(vc *cmdutils.VerbCmd) {
 			"update-auth-data",
 			false,
 			"Whether or not to update the auth data")
+
+		flagSet.MarkDeprecated("auto-ack", "this value is immutable")
+		flagSet.MarkDeprecated("processing-guarantees", "this value is immutable")
+		flagSet.MarkDeprecated("retain-ordering", "this value is immutable")
 	})
 	vc.EnableOutputFlagSet()
 }
@@ -269,6 +273,15 @@ func doUpdateSink(vc *cmdutils.VerbCmd, sinkData *util.SinkData) error {
 	checkArgsForUpdate(sinkData.SinkConf)
 
 	admin := cmdutils.NewPulsarClientWithAPIVersion(common.V3)
+
+	latestConfig, err := admin.Sinks().GetSink(sinkData.Tenant, sinkData.Namespace, sinkData.Name)
+	if err != nil {
+		return err
+	}
+
+	sinkData.SinkConf.AutoAck = latestConfig.AutoAck
+	sinkData.SinkConf.RetainOrdering = latestConfig.RetainOrdering
+	sinkData.SinkConf.ProcessingGuarantees = latestConfig.ProcessingGuarantees
 
 	updateOptions := util.NewUpdateOptions()
 	updateOptions.UpdateAuthData = sinkData.UpdateAuthData

--- a/pkg/ctl/sinks/update_test.go
+++ b/pkg/ctl/sinks/update_test.go
@@ -31,6 +31,5 @@ func TestUpdateSink(t *testing.T) {
 	}
 	_, err, _ := TestSinksCommands(updateSinksCmd, failureUpdateArgs)
 	assert.NotNil(t, err)
-	failMsg := "Sink not-exist doesn't exist"
-	assert.True(t, strings.Contains(err.Error(), failMsg))
+	assert.True(t, strings.Contains(err.Error(), "404"))
 }


### PR DESCRIPTION
Fixes https://github.com/streamnative/pulsarctl/issues/751

### Motivation

In the update sink command, the `auto-ack`, `processing-guarantees`, and `retain-ordering` is immutable.

### Modifications

- Make `auto-ack`, `processing-guarantees`, and `retain-ordering` to deprecated. 
- Do "get" operation to override the `auto-ack`, `processing-guarantees`, and `retain-ordering` value before do "update" operation.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

