### PR TITLE
support oauth2 with auth params

### DIFF
--- a/pkg/auth/auth_provider.go
+++ b/pkg/auth/auth_provider.go
@@ -52,6 +52,10 @@ func GetAuthProvider(config *common.Config) (Provider, error) {
 		fallthrough
 	case TokePluginShortName:
 		provider, err = NewAuthenticationTokenFromAuthParams(config.AuthParams, defaultTransport)
+	case OAuth2PluginName:
+		fallthrough
+	case OAuth2PluginShortName:
+		provider, err = NewAuthenticationOAuth2FromAuthParams(config.AuthParams, defaultTransport)
 	default:
 		switch {
 		case len(config.TLSCertFile) > 0 && len(config.TLSKeyFile) > 0:

--- a/pkg/oauth2/active.go
+++ b/pkg/oauth2/active.go
@@ -62,11 +62,22 @@ func activateCmd(vc *cmdutils.VerbCmd) {
 			"The path to the private key file")
 		set.StringVar(&c.Scope, "scope", c.Scope,
 			"The OAuth 2.0 scope(s) to request")
+		set.StringVar(
+			&c.AuthParams,
+			"auth-params",
+			c.AuthParams,
+			"Authentication parameters are used to configure the OAuth 2.0 provider.\n"+
+				" OAuth2 example: \"{\"audience\":\"test\",\"issuerUrl\":\"https://sample\","+
+				"\"privateKey\":\"/mnt/secrets/auth.json\",\"scope\":\"api://default/\"}\"\n")
 	})
 	vc.EnableOutputFlagSet()
 }
 
 func doActivate(vc *cmdutils.VerbCmd, config *cmdutils.ClusterConfig) error {
+	config, err := applyClientCredentialsToConfig(config)
+	if err != nil {
+		return err
+	}
 	if config.KeyFile == "" {
 		return errors.New("required: key-file")
 	}

--- a/pkg/oauth2/login.go
+++ b/pkg/oauth2/login.go
@@ -63,11 +63,22 @@ func loginCmd(vc *cmdutils.VerbCmd) {
 			"The OAuth 2.0 client identifier for pulsarctl")
 		set.StringVar(&c.Scope, "scope", c.Scope,
 			"The OAuth 2.0 scope(s) to request")
+		set.StringVar(
+			&c.AuthParams,
+			"auth-params",
+			c.AuthParams,
+			"Authentication parameters are used to configure the OAuth 2.0 provider.\n"+
+				" OAuth2 example: \"{\"audience\":\"test\",\"issuerUrl\":\"https://sample\","+
+				"\"privateKey\":\"/mnt/secrets/auth.json\",\"scope\":\"api://default/\"}\"\n")
 	})
 	vc.EnableOutputFlagSet()
 }
 
 func doLogin(vc *cmdutils.VerbCmd, config *cmdutils.ClusterConfig, noRefresh bool) error {
+	config, err := applyClientCredentialsToConfig(config)
+	if err != nil {
+		return err
+	}
 	if config.IssuerEndpoint == "" {
 		return errors.New("required: issuer-endpoint")
 	}


### PR DESCRIPTION
### Motivation

pulsarctl supports passing `--auth-plugin` and `--auth-params` to make them compatible with the `pulsar-admin`, but it is not supporting OAuth2 yet. 

### Modifications

Support passing `--auth-plugin` and `--auth-params` to OAuth 2.0

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

