### PR TITLE
Fix Resource Default Key Names

### DIFF
--- a/pkg/pulsar/utils/resources.go
+++ b/pkg/pulsar/utils/resources.go
@@ -28,9 +28,9 @@ func NewDefaultResources() *Resources {
 		// Default cpu is 1 core
 		CPU: 1,
 		// Default memory is 1GB
-		Disk: 1073741824,
+		RAM: 1073741824,
 		// Default disk is 10GB
-		RAM: 10737418240,
+		Disk: 10737418240,
 	}
 
 	return resources


### PR DESCRIPTION
### Motivation

Noticed when I tried to use the Terraform provider it was giving me 10GB RAM and 1 GB disk as the defaults, even though those should be reversed.  Noticed here that the comment doesn't match the actual key in the map so updated the keys accordingly.

### Modifications

See above, just updated the map keys.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

