### PR TITLE
ci: fix CI broken

### DIFF
--- a/scripts/test-docker/Dockerfile
+++ b/scripts/test-docker/Dockerfile
@@ -14,6 +14,9 @@ ENV PATH /usr/local/go/bin:$PATH
 RUN apt update
 RUN apt install git -y
 
+# install build-essential, includes gcc, g++ and make.
+RUN apt install build-essential -y
+
 # copy the code into image
 COPY . /pulsarctl
 


### PR DESCRIPTION
### Motivation

https://github.com/streamnative/pulsarctl/pull/652 breaks the CI. 

```
# runtime/cgo
cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in $PATH
FAIL	command-line-arguments [build failed]
FAIL
Error: Process completed with exit code 2.
```

### Modifications

Install `build-essential`. 

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

