### PR TITLE
fix: fix token exp

### DIFF
--- a/pkg/pulsar/token.go
+++ b/pkg/pulsar/token.go
@@ -84,10 +84,18 @@ func (t *token) CreateSecretKey(signatureAlgorithm algorithm.Algorithm) ([]byte,
 func (t *token) Create(algorithm algorithm.Algorithm, signKey interface{}, subject string,
 	expireTime int64) (string, error) {
 
-	claims := &jwt.MapClaims{
-		"sub": subject,
-		"exp": jwt.NewNumericDate(time.Unix(expireTime, 0)),
+	var claims *jwt.MapClaims
+	if expireTime == 0 {
+		claims = &jwt.MapClaims{
+			"sub": subject,
+		}
+	} else {
+		claims = &jwt.MapClaims{
+			"sub": subject,
+			"exp": jwt.NewNumericDate(time.Unix(expireTime, 0)),
+		}
 	}
+
 	return t.CreateToken(algorithm, signKey, claims, nil)
 }
 
@@ -110,7 +118,7 @@ func (t *token) Validate(algorithm algorithm.Algorithm, tokenString string,
 	signKey interface{}) (string, int64, error) {
 
 	// verify the signature algorithm
-	parsedToken, err := jwt.ParseWithClaims(tokenString, &jwt.StandardClaims{},
+	parsedToken, err := jwt.ParseWithClaims(tokenString, &jwt.RegisteredClaims{},
 		func(jt *jwt.Token) (i interface{}, e error) {
 			signMethod := parseAlgorithmToJwtSignMethod(algorithm)
 			if jt.Method != signMethod {
@@ -120,8 +128,13 @@ func (t *token) Validate(algorithm algorithm.Algorithm, tokenString string,
 		})
 
 	// get the subject and the expire time
-	if claim, ok := parsedToken.Claims.(*jwt.StandardClaims); parsedToken.Valid && ok {
-		return claim.Subject, claim.ExpiresAt, nil
+	if claim, ok := parsedToken.Claims.(*jwt.RegisteredClaims); parsedToken.Valid && ok {
+		expiresAt := claim.ExpiresAt
+		exp := int64(0)
+		if expiresAt != nil {
+			exp = expiresAt.Unix()
+		}
+		return claim.Subject, exp, nil
 	}
 
 	return "", 0, err

--- a/pkg/pulsar/token.go
+++ b/pkg/pulsar/token.go
@@ -85,7 +85,7 @@ func (t *token) Create(algorithm algorithm.Algorithm, signKey interface{}, subje
 	expireTime int64) (string, error) {
 
 	var claims *jwt.MapClaims
-	if expireTime == 0 {
+	if expireTime <= 0 {
 		claims = &jwt.MapClaims{
 			"sub": subject,
 		}

--- a/pkg/pulsar/token_test.go
+++ b/pkg/pulsar/token_test.go
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"testing"
+	"time"
+
+	"github.com/streamnative/pulsarctl/pkg/pulsar/common/algorithm/algorithm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateToken(t *testing.T) {
+	tokenProvider := token{}
+
+	alg := algorithm.HS256
+	key, err := tokenProvider.CreateSecretKey(alg)
+	require.NoError(t, err)
+
+	subject := "test-role"
+	myToken, err := tokenProvider.Create(alg, key, subject, 0)
+	require.NoError(t, err)
+
+	parsedSubject, exp, err := tokenProvider.Validate(alg, myToken, key)
+	require.NoError(t, err)
+	require.Equal(t, subject, parsedSubject)
+	require.Equal(t, exp, int64(0))
+}
+
+func TestCreateTokenWithExp(t *testing.T) {
+	tokenProvider := token{}
+
+	alg := algorithm.HS256
+	key, err := tokenProvider.CreateSecretKey(alg)
+	require.NoError(t, err)
+
+	subject := "test-role"
+	exp := time.Now().Add(time.Hour).Unix()
+	myToken, err := tokenProvider.Create(alg, key, subject, exp)
+	require.NoError(t, err)
+
+	parsedSubject, exp, err := tokenProvider.Validate(alg, myToken, key)
+	require.NoError(t, err)
+	require.Equal(t, subject, parsedSubject)
+	require.Equal(t, exp, exp)
+}


### PR DESCRIPTION
Fixes #973

### Motivation

https://github.com/streamnative/pulsarctl/pull/906 breaks the token expiration. When a user doesn't set up the expiration, we should not add the `exp` field to the JWT payload.

### Modifications

- Check `expireTime` to determine whether to add `exp` filed to the JWT payload


### Verifying this change

- [x] Make sure that the change passes the CI checks.

Added `token_test.go` test

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

