### PR TITLE
feat: Add Fish shell completion

### DIFF
--- a/docs/en/enable_completion.md
+++ b/docs/en/enable_completion.md
@@ -21,7 +21,7 @@
 
 ## Enabling shell autocompletion
 
-pulsarctl provides autocompletion support for Bash and Zsh, which can save you a lot of typing.
+pulsarctl provides autocompletion support for Bash, Zsh, and Fish, which can save you a lot of typing.
 
 ### Zsh
 
@@ -93,4 +93,18 @@ pulsarctl completion bash >/usr/local/etc/bash_completion.d/pulsarctl.bash
 ```bash
 echo 'source /usr/local/etc/bash_completion.d/pulsarctl.bash' >> ~/.bashrc
 source ~/.bashrc
+```
+
+### Fish
+
+To load completions once in your current session run:
+		
+```bash
+pulsarctl completion fish | source
+```
+
+To load completions for each session, run:
+
+```bash
+pulsarctl completion fish > ~/.config/fish/completions/pulsarctl.fish
 ```

--- a/pkg/ctl/completion/completion.go
+++ b/pkg/ctl/completion/completion.go
@@ -65,6 +65,22 @@ rm -f ~/.zcompdump; compinit
 		},
 	}
 
+	var fishCompletionCmd = &cobra.Command{
+		Use:   "fish",
+		Short: "Generates Fish completion scripts",
+		Long: `To load completions run:
+
+pulsarctl completion fish | source
+
+		To load completions for each session, run:
+
+pulsarctl completion fish > ~/.config/fish/completions/pulsarctl.fish
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return rootCmd.GenFishCompletion(os.Stdout, true)
+		},
+	}
+
 	cmd := &cobra.Command{
 		Use:   "completion",
 		Short: "Generates shell completion scripts",
@@ -77,6 +93,7 @@ rm -f ~/.zcompdump; compinit
 
 	cmd.AddCommand(bashCompletionCmd)
 	cmd.AddCommand(zshCompletionCmd)
+	cmd.AddCommand(fishCompletionCmd)
 
 	return cmd
 }


### PR DESCRIPTION
### Motivation

Users of the Fish shell would like to have auto completion too.

### Modifications

Added the `pulsarctl completion fish` sub command to generate fish auto completion.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `doc` 
  