### PR TITLE
Updated version check to use github API and pull latest release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@
 set -e
 
 if [[ "x${version}" == "x" ]]; then
-    version=$(curl -s https://raw.githubusercontent.com/streamnative/pulsarctl/master/stable.txt)
+    version=$(curl -s https://api.github.com/repos/streamnative/pulsarctl/releases/latest | grep tag_name | sed -r 's/.*(v[[:digit:]]+(\.[[:digit:]]+)+).*/\1/')
 fi
 
 discoverArch() {


### PR DESCRIPTION
Fixes #854


### Motivation

install.sh references a static file inn the repo, stable.txt which hasn't been updated for some time. The install.sh script is referenced by other projects (I stumbled on this from the apache pulsar helm chart https://github.com/apache/pulsar-helm-chart/blob/8ad7cf6b6508a23546a8d5a66e5319cf36f39712/scripts/pulsar/common_auth.sh#L61). This change would prevent anyone from having to update stable.txt manually again (at least as far as the install.sh script is concerned).

### Modifications
version=$(curl -s https://api.github.com/repos/streamnative/pulsarctl/releases/latest | grep tag_name | sed -r 's/.*(v[[:digit:]]+(\.[[:digit:]]+)+).*/\1/')


This change is a trivial rework / code cleanup without any test coverage.


### Documentation
  
- [x] `no-need-doc` 
  
 This is an automated script.
  

