### PR TITLE
fix policies typo

### DIFF
--- a/pkg/ctl/namespace/create.go
+++ b/pkg/ctl/namespace/create.go
@@ -124,7 +124,7 @@ func doCreate(vc *cmdutils.VerbCmd, data utils.NamespacesData) error {
 		policies.ReplicationClusters = data.Clusters
 	}
 
-	err = admin.Namespaces().CreateNsWithPolices(ns.String(), *policies)
+	err = admin.Namespaces().CreateNsWithPolicies(ns.String(), *policies)
 	if err == nil {
 		vc.Command.Printf("Created %s successfully\n", ns.String())
 	}

--- a/pkg/ctl/namespace/policies_test.go
+++ b/pkg/ctl/namespace/policies_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPolicesCommand(t *testing.T) {
+func TestPoliciesCommand(t *testing.T) {
 	args := []string{"create", "public/test-policy-namespace"}
 	createOut, _, _, err := TestNamespaceCommands(createNs, args)
 	assert.Nil(t, err)
@@ -51,21 +51,21 @@ func TestPolicesCommand(t *testing.T) {
 	}
 }
 
-func TestPolicesNsArgsError(t *testing.T) {
+func TestPoliciesNsArgsError(t *testing.T) {
 	args := []string{"policies"}
 	_, _, nameErr, _ := TestNamespaceCommands(getPolicies, args)
 	assert.Equal(t, "the namespace name is not specified or the namespace name is "+
 		"specified more than one", nameErr.Error())
 }
 
-func TestPolicesNonExistTenant(t *testing.T) {
+func TestPoliciesNonExistTenant(t *testing.T) {
 	args := []string{"policies", "non-existent-tenant/default"}
 	_, execErr, _, _ := TestNamespaceCommands(getPolicies, args)
 	assert.NotNil(t, execErr)
 	assert.Equal(t, "code: 404 reason: Namespace does not exist", execErr.Error())
 }
 
-func TestPolicesNonExistNs(t *testing.T) {
+func TestPoliciesNonExistNs(t *testing.T) {
 	args := []string{"policies", "public/test-not-exist-ns"}
 	_, execErr, _, _ := TestNamespaceCommands(getPolicies, args)
 	assert.NotNil(t, execErr)


### PR DESCRIPTION
### Motivation

* fix typo `polices` by changing it to `policies` everywhere

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

