### PR TITLE
fix: Fix TestUpdateTopicNotExist and TestUpdateNonPartitionedTopic

### DIFF
--- a/pkg/ctl/topic/update_test.go
+++ b/pkg/ctl/topic/update_test.go
@@ -19,6 +19,7 @@ package topic
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/streamnative/pulsar-admin-go/pkg/utils"
@@ -82,7 +83,7 @@ func TestUpdateTopicNotExist(t *testing.T) {
 	args := []string{"update", "non-exist-topic", "2"}
 	_, execErr, _, _ := TestTopicCommands(UpdateTopicCmd, args)
 	assert.NotNil(t, execErr)
-	assert.Equal(t, "code: 409 reason: Topic is not partitioned topic", execErr.Error())
+	assert.True(t, strings.Contains(execErr.Error(), "is not partitioned topic"))
 }
 
 func TestUpdateNonPartitionedTopic(t *testing.T) {
@@ -93,5 +94,5 @@ func TestUpdateNonPartitionedTopic(t *testing.T) {
 	args = []string{"update", "test-update-non-partitioned-topic", "3"}
 	_, execErr, _, _ = TestTopicCommands(UpdateTopicCmd, args)
 	assert.NotNil(t, execErr)
-	assert.Equal(t, "code: 409 reason: Topic is not partitioned topic", execErr.Error())
+	assert.True(t, strings.Contains(execErr.Error(), "is not partitioned topic"))
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

There is two failed tests when using Pulsar 3.0.0:
```
=== RUN   TestUpdateTopicNotExist
    update_test.go:85: 
        	Error Trace:	/pulsarctl/pkg/ctl/topic/update_test.go:85
        	Error:      	Not equal: 
        	            	expected: "code: 409 reason: Topic is not partitioned topic"
        	            	actual  : "code: 409 reason: Topic persistent://public/default/non-exist-topic is not the partitioned topic."
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-code: 409 reason: Topic is not partitioned topic
        	            	+code: 409 reason: Topic persistent://public/default/non-exist-topic is not the partitioned topic.
        	Test:       	TestUpdateTopicNotExist
--- FAIL: TestUpdateTopicNotExist (0.01s)
=== RUN   TestUpdateNonPartitionedTopic
    update_test.go:96: 
        	Error Trace:	/pulsarctl/pkg/ctl/topic/update_test.go:96
        	Error:      	Not equal: 
        	            	expected: "code: 409 reason: Topic is not partitioned topic"
        	            	actual  : "code: 409 reason: Topic persistent://public/default/test-update-non-partitioned-topic is not the partitioned topic."
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-code: 409 reason: Topic is not partitioned topic
        	            	+code: 409 reason: Topic persistent://public/default/test-update-non-partitioned-topic is not the partitioned topic.
        	Test:       	TestUpdateNonPartitionedTopic
--- FAIL: TestUpdateNonPartitionedTopic (0.02s)
```

More details in https://github.com/streamnative/pulsarctl/actions/runs/4976702208/jobs/8905382299?pr=1064#step:3:1349

This is because we change the log message in Pulsar 3.0.0 by this PR: https://github.com/apache/pulsar/pull/19166

### Modifications

* Fix the assert of the test


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

