### PR TITLE
feat: auto activate oauth2 client credentials

### DIFF
--- a/pkg/cmdutils/config.go
+++ b/pkg/cmdutils/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/magiconair/properties"
 	"github.com/spf13/pflag"
 	"github.com/streamnative/pulsar-admin-go/pkg/admin"
+	"github.com/streamnative/pulsar-admin-go/pkg/admin/auth"
 	"github.com/streamnative/pulsar-admin-go/pkg/admin/config"
 	"github.com/streamnative/pulsar-admin-go/pkg/utils"
 	"gopkg.in/yaml.v2"
@@ -163,17 +164,18 @@ func (c *ClusterConfig) ApplyContext(ctxConf *Config, contextName *string) {
 			c.WebServiceURL = ctx.BrokerServiceURL
 			c.BKWebServiceURL = ctx.BookieServiceURL
 		}
-		auth, exist := ctxConf.AuthInfos[*contextName]
+		authInfo, exist := ctxConf.AuthInfos[*contextName]
 		if exist {
-			c.TLSTrustCertsFilePath = auth.TLSTrustCertsFilePath
-			c.TLSAllowInsecureConnection = auth.TLSAllowInsecureConnection
-			c.Token = auth.Token
-			c.TokenFile = auth.TokenFile
-			c.IssuerEndpoint = auth.IssuerEndpoint
-			c.ClientID = auth.ClientID
-			c.Audience = auth.Audience
-			c.KeyFile = auth.KeyFile
-			c.Scope = auth.Scope
+			c.TLSTrustCertsFilePath = authInfo.TLSTrustCertsFilePath
+			c.TLSAllowInsecureConnection = authInfo.TLSAllowInsecureConnection
+			c.Token = authInfo.Token
+			c.TokenFile = authInfo.TokenFile
+			c.IssuerEndpoint = authInfo.IssuerEndpoint
+			c.ClientID = authInfo.ClientID
+			c.Audience = authInfo.Audience
+			c.KeyFile = authInfo.KeyFile
+			c.Scope = authInfo.Scope
+			c.AuthPlugin = auth.OAuth2PluginName
 		}
 	}
 }

--- a/pkg/oauth2/active.go
+++ b/pkg/oauth2/active.go
@@ -30,7 +30,7 @@ import (
 
 func activateCmd(vc *cmdutils.VerbCmd) {
 	desc := cmdutils.LongDescription{}
-	desc.CommandUsedFor = "This command is used for activating a service account by supplying its credentials."
+	desc.CommandUsedFor = "[Deprecated] This command is used for activating a service account by supplying its credentials."
 	desc.CommandPermission = "This command doesn't need pulsar permissions."
 
 	var examples []cmdutils.Example

--- a/pkg/oauth2/active.go
+++ b/pkg/oauth2/active.go
@@ -30,7 +30,7 @@ import (
 
 func activateCmd(vc *cmdutils.VerbCmd) {
 	desc := cmdutils.LongDescription{}
-	desc.CommandUsedFor = "[Deprecated] This command is used for activating a service account by supplying its credentials."
+	desc.CommandUsedFor = "[Deprecated] This command is used for activating a service account by supplying its credentials." //nolint:lll
 	desc.CommandPermission = "This command doesn't need pulsar permissions."
 
 	var examples []cmdutils.Example


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #1073

### Motivation

For the OAuth2 client_credentials type, there is no necessity to involve user interaction.
It can auto retrieve credentials. The upstream pulsar-admin-go already support this.

### Modifications

- Auto retrieve credentials
- Mark `pulsarctl oauth2 activate` deprecated

### Verifying this change

```
pulsarctl context set velero  \
    --admin-service-url {} \
    --issuer-endpoint {}\
    --audience{{audience}} \
    --key-file {}

pulsarctl tenants list  // no more pulsarctl oauth2 activate
```

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

