### PR TITLE
Set parallelism to 1 only when it is smaller than 1

### DIFF
--- a/pkg/ctl/functions/util.go
+++ b/pkg/ctl/functions/util.go
@@ -160,7 +160,7 @@ func processArgs(funcData *util.FunctionData) error {
 
 	if funcData.Parallelism != 0 {
 		funcData.FuncConf.Parallelism = funcData.Parallelism
-	} else {
+	} else if funcData.FuncConf.Parallelism <= 0 {
 		funcData.FuncConf.Parallelism = 1
 	}
 

--- a/pkg/ctl/sinks/util.go
+++ b/pkg/ctl/sinks/util.go
@@ -119,7 +119,7 @@ func processArguments(sinkData *util.SinkData) error {
 
 	if sinkData.Parallelism != 0 {
 		sinkData.SinkConf.Parallelism = sinkData.Parallelism
-	} else {
+	} else if sinkData.SinkConf.Parallelism <= 0 {
 		sinkData.SinkConf.Parallelism = 1
 	}
 

--- a/pkg/ctl/sources/util.go
+++ b/pkg/ctl/sources/util.go
@@ -88,7 +88,7 @@ func processArguments(sourceData *util.SourceData) error {
 
 	if sourceData.Parallelism != 0 {
 		sourceData.SourceConf.Parallelism = sourceData.Parallelism
-	} else {
+	} else if sourceData.SourceConf.Parallelism <= 0 {
 		sourceData.SourceConf.Parallelism = 1
 	}
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #1107 

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

the program always sets the parallelism to the default value(1) even if the config file is specified and a valid parallelism in it

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

