### PR TITLE
Fix not return error when set not exist sink-config-file.

### DIFF
--- a/pkg/ctl/sinks/create_test.go
+++ b/pkg/ctl/sinks/create_test.go
@@ -42,3 +42,15 @@ func TestCreateSinkFailedByEmptyFile(t *testing.T) {
 	failImmediatelyIfErrorNotNil(t, err)
 	assert.NotNil(t, execErr)
 }
+
+func TestCreateSinkFailedByNotExistSinkConfigFile(t *testing.T) {
+	failedArgs := []string{
+		"create",
+		"--name", "failed-create",
+		"--inputs", "failed-inputs",
+		"--sink-config-file", "/tmp/failed-config.yaml",
+	}
+	_, execErr, err := TestSinksCommands(createSinksCmd, failedArgs)
+	failImmediatelyIfErrorNotNil(t, err)
+	assert.NotNil(t, execErr)
+}

--- a/pkg/ctl/sinks/util.go
+++ b/pkg/ctl/sinks/util.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -49,7 +48,7 @@ func processArguments(sinkData *util.SinkData) error {
 			if err != nil {
 				return fmt.Errorf("unmarshal yaml file error:%s", err.Error())
 			}
-		} else if os.IsNotExist(err) {
+		} else {
 			return fmt.Errorf("load conf file failed, err:%s", err.Error())
 		}
 	}

--- a/pkg/ctl/sinks/util.go
+++ b/pkg/ctl/sinks/util.go
@@ -49,7 +49,7 @@ func processArguments(sinkData *util.SinkData) error {
 			if err != nil {
 				return fmt.Errorf("unmarshal yaml file error:%s", err.Error())
 			}
-		} else if !os.IsNotExist(err) {
+		} else if os.IsNotExist(err) {
 			return fmt.Errorf("load conf file failed, err:%s", err.Error())
 		}
 	}

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -3,7 +3,7 @@ set -e
 
 readonly PROJECT_ROOT=`cd $(dirname $0)/..; pwd`
 readonly IMAGE_NAME=pulsarctl-test
-readonly PULSAR_DEFAULT_VERSION="3.0.0.4"
+readonly PULSAR_DEFAULT_VERSION="3.0.0.4-gidrootless"
 readonly PULSAR_VERSION=${PULSAR_VERSION:-${PULSAR_DEFAULT_VERSION}}
 
 docker build --build-arg PULSAR_VERSION=${PULSAR_VERSION} \


### PR DESCRIPTION
### Motivation

When creating a sink connector, if set a not exist `sink-config-file`, it will create success.

### Modifications

- Change the `sink-config-file` to verify the logic.

### Verifying this change

- Add `TestCreateSinkFailedByNotExistSinkConfigFile` to cover it.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

