### PR TITLE
fix-cve-2014-9357

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible // indirect
-	github.com/docker/docker v0.7.3-0.20190506211059-b20a14b54661 // indirect
+	github.com/docker/docker v1.3.3 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect


### PR DESCRIPTION

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

### Motivation

fix-cve-2014-9357 
github.com/docker/docker is old

### Modifications
pulsarctl is major cli for sn and 2014-9357 is Critical CVE. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
I did a simple make pulsarctl on my macOS and it is succeed. 


This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

