### PR TITLE
Revert docker build base image

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -3,7 +3,7 @@ set -e
 
 readonly PROJECT_ROOT=`cd $(dirname $0)/..; pwd`
 readonly IMAGE_NAME=pulsarctl-test
-readonly PULSAR_DEFAULT_VERSION="3.0.0.4-gidrootless"
+readonly PULSAR_DEFAULT_VERSION="3.0.1.1"
 readonly PULSAR_VERSION=${PULSAR_VERSION:-${PULSAR_DEFAULT_VERSION}}
 
 docker build --build-arg PULSAR_VERSION=${PULSAR_VERSION} \

--- a/scripts/test-docker/Dockerfile
+++ b/scripts/test-docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG PULSAR_VERSION
-FROM docker.cloudsmith.io/streamnative/staging/pulsar-all:$PULSAR_VERSION
+FROM streamnative/pulsar-all:$PULSAR_VERSION
 
 # use root user
 USER root


### PR DESCRIPTION
### Motivation

sn-ci replaces this docker base image, we don't need to specify it with the staging repository addr.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

