### PR TITLE
Add method to mark bookie readonly

### DIFF
--- a/pkg/bkctl/bookie/set_readonly_state.go
+++ b/pkg/bkctl/bookie/set_readonly_state.go
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package bookie
+
+import (
+	"strconv"
+
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+)
+
+func setReadonlyStateCmd(vc *cmdutils.VerbCmd) {
+	var desc cmdutils.LongDescription
+	desc.CommandUsedFor = "This command is used for setting the readonly state of a bookie."
+	desc.CommandPermission = "This command does not need any permission."
+
+	var examples []cmdutils.Example
+	get := cmdutils.Example{
+		Desc:    "Set the readonly state of the bookie.",
+		Command: "pulsarctl bookkeeper bookie set-readonly <true/false>",
+	}
+	examples = append(examples, get)
+	desc.CommandExamples = examples
+
+	var out []cmdutils.Output
+	successOut := cmdutils.Output{
+		Desc: "Successfully set the readonly state of a bookie.",
+		Out:  "Successfully set the readonly state of a bookie",
+	}
+	out = append(out, successOut)
+	desc.CommandOutput = out
+
+	vc.SetDescription(
+		"set-readonly",
+		"Set the readonly state of a bookie.",
+		desc.ToString(),
+		desc.ExampleToString())
+
+	vc.SetRunFuncWithNameArg(func() error {
+		return doSetReadonlyState(vc)
+	}, "the readonly state is boolean")
+}
+
+func doSetReadonlyState(vc *cmdutils.VerbCmd) error {
+	admin := cmdutils.NewBookieClient()
+	readonly, err := strconv.ParseBool(vc.NameArg)
+	if err != nil {
+		return err
+	}
+	err = admin.Bookie().SetReadonlyState(readonly)
+	if err == nil {
+		cmdutils.PrintJSON(vc.Command.OutOrStdout(), "Successfully set the readonly state of a bookie")
+	}
+
+	return err
+}

--- a/pkg/bkctl/bookie/set_readonly_state_test.go
+++ b/pkg/bkctl/bookie/set_readonly_state_test.go
@@ -18,28 +18,16 @@
 package bookie
 
 import (
-	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	"testing"
 
-	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
-func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
-	resourceCmd := cmdutils.NewResourceCmd(
-		"bookie",
-		"Operations about one bookie",
-		"")
-
-	commands := []func(*cmdutils.VerbCmd){
-		lastLogMarkCmd,
-		listDiskFileCmd,
-		expandStorageCmd,
-		gcCmd,
-		gcStatusCmd,
-		gcDetailsCmd,
-		stateCmd,
-		setReadonlyStateCmd,
-	}
-
-	cmdutils.AddVerbCmds(flagGrouping, resourceCmd, commands...)
-	return resourceCmd
+func TestSetReadonlyStateCmd(t *testing.T) {
+	args := []string{"set-readonly", "true"}
+	out, execErr, nameErr, err := testBookieCommands(setReadonlyStateCmd, args)
+	assert.Nil(t, err)
+	assert.Nil(t, nameErr)
+	assert.Nil(t, execErr)
+	assert.Equal(t, "Successfully set the readonly state of a bookie\n", out.String())
 }

--- a/pkg/bkctl/bookie/set_readonly_state_test.go
+++ b/pkg/bkctl/bookie/set_readonly_state_test.go
@@ -29,5 +29,5 @@ func TestSetReadonlyStateCmd(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, nameErr)
 	assert.Nil(t, execErr)
-	assert.Equal(t, "Successfully set the readonly state of a bookie\n", out.String())
+	assert.Equal(t, "\"Successfully set the readonly state of a bookie\"\n", out.String())
 }

--- a/pkg/bkctl/bookie/set_readonly_state_test.go
+++ b/pkg/bkctl/bookie/set_readonly_state_test.go
@@ -30,4 +30,12 @@ func TestSetReadonlyStateCmd(t *testing.T) {
 	assert.Nil(t, nameErr)
 	assert.Nil(t, execErr)
 	assert.Equal(t, "\"Successfully set the readonly state of a bookie\"\n", out.String())
+
+	// set back to false, otherwise the next test will fail
+	args = []string{"set-readonly", "false"}
+	out, execErr, nameErr, err = testBookieCommands(setReadonlyStateCmd, args)
+	assert.Nil(t, err)
+	assert.Nil(t, nameErr)
+	assert.Nil(t, execErr)
+	assert.Equal(t, "\"Successfully set the readonly state of a bookie\"\n", out.String())
 }

--- a/pkg/bookkeeper/bkdata/bookie_data.go
+++ b/pkg/bookkeeper/bkdata/bookie_data.go
@@ -31,6 +31,10 @@ type GCStatus struct {
 	MinorCompactionCounter  int64 `json:"minorCompactionCounter"`
 }
 
+type ReadonlyState struct {
+	ReadOnly bool `json:"readOnly"`
+}
+
 type State struct {
 	Running                        bool `json:"running"`
 	ReadOnly                       bool `json:"readOnly"`

--- a/pkg/bookkeeper/bookie.go
+++ b/pkg/bookkeeper/bookie.go
@@ -42,6 +42,9 @@ type Bookie interface {
 
 	// State gets the state of a bookie
 	State() (*bkdata.State, error)
+
+	// SetReadonlyState sets the readonly state of a bookie
+	SetReadonlyState(bool) error
 }
 
 type bookie struct {
@@ -56,6 +59,14 @@ func (c *bookieClient) Bookie() Bookie {
 		basePath: "/bookie",
 		params:   make(map[string]string),
 	}
+}
+
+func (b *bookie) SetReadonlyState(readonly bool) error {
+	endpoint := b.bk.endpoint(b.basePath, "/state/readonly")
+	request := bkdata.ReadonlyState{
+		ReadOnly: readonly,
+	}
+	return b.bk.Client.Put(endpoint, &request)
 }
 
 func (b *bookie) LastLogMark() (map[string]string, error) {

--- a/pkg/cmdutils/cmdutils.go
+++ b/pkg/cmdutils/cmdutils.go
@@ -170,10 +170,6 @@ func NewBookieClient() bookkeeper.Client {
 	return PulsarCtlConfig.BookieClient()
 }
 
-func NewBookieClientFromConfig(config *ClusterConfig) bookkeeper.Client {
-	return config.BookieClient()
-}
-
 func PrintJSON(w io.Writer, obj interface{}) {
 	b, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {

--- a/pkg/cmdutils/cmdutils.go
+++ b/pkg/cmdutils/cmdutils.go
@@ -170,6 +170,10 @@ func NewBookieClient() bookkeeper.Client {
 	return PulsarCtlConfig.BookieClient()
 }
 
+func NewBookieClientFromConfig(config *ClusterConfig) bookkeeper.Client {
+	return config.BookieClient()
+}
+
 func PrintJSON(w io.Writer, obj interface{}) {
 	b, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   zookeeper:
     container_name: bk-zookeeper
-    image: "apache/bookkeeper:4.10.0"
+    image: "apache/bookkeeper:4.16.3"
     hostname: zookeeper
     entrypoint:
       - /bin/bash
@@ -13,7 +13,7 @@ services:
     depends_on:
       - zookeeper
       - bookie-init
-    image: "apache/bookkeeper:4.10.0"
+    image: "apache/bookkeeper:4.16.3"
     hostname: bookie
     links:
       - zookeeper
@@ -32,7 +32,7 @@ services:
         /opt/bookkeeper/bin/bookkeeper bookie
     restart: on-failure
   bookie-init:
-    image: "apache/bookkeeper:4.10.0"
+    image: "apache/bookkeeper:4.16.3"
     hostname: bookie-client
     links:
       - zookeeper


### PR DESCRIPTION
1. Add interface to set bookie readonly.
2. ~Add `NewBookieClientFromConfig`. In the pulsar operator, we can't use global shared `PulsarCtlConfig`~.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

