### PR TITLE
fix: fix command aliases

### DIFF
--- a/pkg/bkctl/autorecovery/autorecovery.go
+++ b/pkg/bkctl/autorecovery/autorecovery.go
@@ -27,7 +27,6 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	resourceCmd := cmdutils.NewResourceCmd(
 		"auto-recovery",
 		"Operations about auto recovering",
-		"",
 		"")
 
 	commands := []func(*cmdutils.VerbCmd){

--- a/pkg/bkctl/autorecovery/test_help.go
+++ b/pkg/bkctl/autorecovery/test_help.go
@@ -48,7 +48,6 @@ func testAutoRecoveryCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string
 	resourceCmd := cmdutils.NewResourceCmd(
 		"auto-recovery",
 		"Operations about auto recovering",
-		"",
 		"")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)

--- a/pkg/bkctl/bookie/test_help.go
+++ b/pkg/bkctl/bookie/test_help.go
@@ -56,7 +56,6 @@ func testBookieCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (out
 	resourceCmd := cmdutils.NewResourceCmd(
 		"bookie",
 		"Operations about bookie(s)",
-		"",
 		"")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)

--- a/pkg/bkctl/ledger/ledger.go
+++ b/pkg/bkctl/ledger/ledger.go
@@ -27,7 +27,6 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	resourceCmd := cmdutils.NewResourceCmd(
 		"ledger",
 		"Operations about ledger",
-		"",
 		"")
 
 	commands := []func(*cmdutils.VerbCmd){

--- a/pkg/bkctl/ledger/test_help.go
+++ b/pkg/bkctl/ledger/test_help.go
@@ -56,7 +56,6 @@ func testLedgerCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (out
 	resourceCmd := cmdutils.NewResourceCmd(
 		"ledger",
 		"Operations about bookie(s)",
-		"",
 		"")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)

--- a/pkg/ctl/brokers/test_help.go
+++ b/pkg/ctl/brokers/test_help.go
@@ -55,7 +55,7 @@ func TestBrokersCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (ou
 		"brokers",
 		"Operations about broker(s)",
 		"",
-		"brokers")
+		"broker")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/brokerstats/broker_stats.go
+++ b/pkg/ctl/brokerstats/broker_stats.go
@@ -26,8 +26,7 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	resourceCmd := cmdutils.NewResourceCmd(
 		"broker-stats",
 		"Operations to collect broker statistics",
-		"",
-		"broker-stats")
+		"")
 
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, dumpMonitoringMetrics)
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, dumpMBeans)

--- a/pkg/ctl/brokerstats/test_help.go
+++ b/pkg/ctl/brokerstats/test_help.go
@@ -54,8 +54,7 @@ func TestBrokerStatsCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string)
 	resourceCmd := cmdutils.NewResourceCmd(
 		"broker-stats",
 		"Operations to collect broker statistics",
-		"",
-		"broker-stats")
+		"")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/cluster/list.go
+++ b/pkg/ctl/cluster/list.go
@@ -56,7 +56,6 @@ func ListClustersCmd(vc *cmdutils.VerbCmd) {
 		"List the available pulsar clusters",
 		"This command is used for listing the list of available pulsar clusters.",
 		desc.ExampleToString(),
-		"",
 	)
 
 	// set the run function

--- a/pkg/ctl/functions/test_help.go
+++ b/pkg/ctl/functions/test_help.go
@@ -53,7 +53,7 @@ func TestFunctionsCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (
 		"functions",
 		"Operations about Pulsar Functions",
 		"",
-		"functions")
+		"pf")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/functionsworker/test_help.go
+++ b/pkg/ctl/functionsworker/test_help.go
@@ -55,7 +55,7 @@ func TestFunctionsWorkerCmd(newVerb func(cmd *cmdutils.VerbCmd), args []string) 
 		"functions-worker",
 		"Operations to collect function-worker statistics",
 		"",
-		"functions-worker")
+		"pfw")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/nsisolationpolicy/ns_isolation_policy.go
+++ b/pkg/ctl/nsisolationpolicy/ns_isolation_policy.go
@@ -35,8 +35,7 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	resourceCmd := cmdutils.NewResourceCmd(
 		"ns-isolation-policy",
 		"Operations about namespace isolation policy",
-		"",
-		"ns-isolation-policy")
+		"")
 
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, getNsIsolationPolicy)
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, getNsIsolationPolicies)

--- a/pkg/ctl/nsisolationpolicy/test_help.go
+++ b/pkg/ctl/nsisolationpolicy/test_help.go
@@ -55,8 +55,7 @@ func TestNsIsolationPolicyCommands(newVerb func(cmd *cmdutils.VerbCmd), args []s
 	resourceCmd := cmdutils.NewResourceCmd(
 		"ns-isolation-policy",
 		"Operations about namespace isolation policy",
-		"",
-		"ns-isolation-policy")
+		"")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/packages/test_help.go
+++ b/pkg/ctl/packages/test_help.go
@@ -51,8 +51,7 @@ func TestPackagesCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (o
 	resourceCmd := cmdutils.NewResourceCmd(
 		"packages",
 		"Operations about packages",
-		"",
-		"packages")
+		"")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/plugin/test_help.go
+++ b/pkg/ctl/plugin/test_help.go
@@ -36,7 +36,11 @@ func testPluginCommands(newVerb func(*cmdutils.VerbCmd), args []string) (out *by
 	rootCmd.SetArgs(append([]string{"plugin"}, args...))
 	flagGrouping := cmdutils.NewGrouping()
 	rootCmd.AddCommand(Command(flagGrouping))
-	resourceCmd := cmdutils.NewResourceCmd("plugin", "", "")
+	resourceCmd := cmdutils.NewResourceCmd(
+		"plugin",
+		"Operations about plugins",
+		"",
+		"plugins")
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	err = rootCmd.Execute()
 	return

--- a/pkg/ctl/resourcequotas/resource_quotas.go
+++ b/pkg/ctl/resourcequotas/resource_quotas.go
@@ -26,8 +26,7 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	resourceCmd := cmdutils.NewResourceCmd(
 		"resource-quotas",
 		"Operations about resource quotas",
-		"",
-		"resource-quotas")
+		"")
 
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, getResourceQuota)
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, setResourceQuota)

--- a/pkg/ctl/resourcequotas/test_help.go
+++ b/pkg/ctl/resourcequotas/test_help.go
@@ -55,8 +55,7 @@ func TestResourceQuotaCommands(newVerb func(cmd *cmdutils.VerbCmd), args []strin
 	resourceCmd := cmdutils.NewResourceCmd(
 		"resource-quota",
 		"Operations about resource quotas",
-		"",
-		"resource-quota")
+		"")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/schemas/schemas.go
+++ b/pkg/ctl/schemas/schemas.go
@@ -33,9 +33,7 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	resourceCmd := cmdutils.NewResourceCmd(
 		"schemas",
 		"Operations related to Schemas associated with Pulsar topics",
-		"",
-		"schemas",
-	)
+		"")
 
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, getSchema)
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, deleteSchema)

--- a/pkg/ctl/schemas/test_help.go
+++ b/pkg/ctl/schemas/test_help.go
@@ -49,8 +49,7 @@ func TestSchemasCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (ou
 	resourceCmd := cmdutils.NewResourceCmd(
 		"schemas",
 		"Operations about schemas",
-		"",
-		"schemas")
+		"")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/sinks/sinks.go
+++ b/pkg/ctl/sinks/sinks.go
@@ -27,9 +27,7 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	resourceCmd := cmdutils.NewResourceCmd(
 		"sinks",
 		"Interface for managing Pulsar IO sinks (egress data from Pulsar)",
-		"",
-		"sinks",
-	)
+		"")
 
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, createSinksCmd)
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, updateSinksCmd)

--- a/pkg/ctl/sinks/test_help.go
+++ b/pkg/ctl/sinks/test_help.go
@@ -52,8 +52,7 @@ func TestSinksCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (out 
 	resourceCmd := cmdutils.NewResourceCmd(
 		"sinks",
 		"Operations about Pulsar Sinks",
-		"",
-		"sinks")
+		"")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/sources/sources.go
+++ b/pkg/ctl/sources/sources.go
@@ -27,9 +27,7 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	resourceCmd := cmdutils.NewResourceCmd(
 		"sources",
 		"Interface for managing Pulsar IO Sources (ingress data into Pulsar)",
-		"",
-		"sources",
-	)
+		"")
 
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, createSourcesCmd)
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, updateSourcesCmd)

--- a/pkg/ctl/sources/test_help.go
+++ b/pkg/ctl/sources/test_help.go
@@ -52,8 +52,7 @@ func TestSourcesCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (ou
 	resourceCmd := cmdutils.NewResourceCmd(
 		"sources",
 		"Operations about Pulsar Sources",
-		"",
-		"sources")
+		"")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/status/status.go
+++ b/pkg/ctl/status/status.go
@@ -26,8 +26,7 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	statusCmd := cmdutils.NewResourceCmd(
 		"status",
 		"Check service(broker or proxy) status",
-		"",
-		"status")
+		"")
 	cmdutils.AddVerbCmd(flagGrouping, statusCmd, checkStatusCmd)
 
 	return statusCmd

--- a/pkg/ctl/status/test_help.go
+++ b/pkg/ctl/status/test_help.go
@@ -39,8 +39,7 @@ func testStatusCommands(newVerb func(*cmdutils.VerbCmd), args []string) (out *by
 	resourceCmd := cmdutils.NewResourceCmd(
 		"status",
 		"Check service(broker or proxy) status",
-		"",
-		"status")
+		"")
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	err = rootCmd.Execute()
 	return

--- a/pkg/ctl/subscription/test_help.go
+++ b/pkg/ctl/subscription/test_help.go
@@ -57,7 +57,7 @@ func TestSubCommands(newVerb func(cmd *cmdutils.VerbCmd), args []string) (out *b
 		"subscriptions",
 		"Operations about subscription(s)",
 		"",
-		"subscription")
+		"subscription", "subs", "sub")
 	flagGrouping := cmdutils.NewGrouping()
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	rootCmd.AddCommand(resourceCmd)

--- a/pkg/ctl/token/test_help.go
+++ b/pkg/ctl/token/test_help.go
@@ -38,7 +38,10 @@ func testTokenCommands(newVerb func(*cmdutils.VerbCmd), args []string) (out *byt
 	rootCmd.SetArgs(append([]string{"token"}, args...))
 	flagGrouping := cmdutils.NewGrouping()
 	rootCmd.AddCommand(Command(flagGrouping))
-	resourceCmd := cmdutils.NewResourceCmd("token", "", "")
+	resourceCmd := cmdutils.NewResourceCmd(
+		"token",
+		"Operations of token",
+		"You can use this tool to generate secret key, private/public key, and token.")
 	cmdutils.AddVerbCmd(flagGrouping, resourceCmd, newVerb)
 	err = rootCmd.Execute()
 

--- a/pkg/ctl/token/token.go
+++ b/pkg/ctl/token/token.go
@@ -27,8 +27,7 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	resourceCmd := cmdutils.NewResourceCmd(
 		"token",
 		"Operations of token",
-		"You can use this tool to generate secret key, private/public key, and token.",
-		"")
+		"You can use this tool to generate secret key, private/public key, and token.")
 
 	cmds := []func(*cmdutils.VerbCmd){
 		createKeyPair,

--- a/pkg/ctl/topic/bundle_range.go
+++ b/pkg/ctl/topic/bundle_range.go
@@ -51,8 +51,7 @@ func GetBundleRangeCmd(vc *cmdutils.VerbCmd) {
 		"bundle-range",
 		"Get the namespace bundle range of a topic",
 		desc.ToString(),
-		desc.ExampleToString(),
-		"")
+		desc.ExampleToString())
 
 	vc.SetRunFuncWithNameArg(func() error {
 		return doGetBundleRange(vc)

--- a/pkg/ctl/topic/lookup_topic.go
+++ b/pkg/ctl/topic/lookup_topic.go
@@ -56,8 +56,7 @@ func LookUpTopicCmd(vc *cmdutils.VerbCmd) {
 		"lookup",
 		"Look up a topic",
 		desc.ToString(),
-		desc.ExampleToString(),
-		"")
+		desc.ExampleToString())
 
 	vc.SetRunFuncWithNameArg(func() error {
 		return doLookupTopic(vc)

--- a/pkg/ctl/topic/stats_internal.go
+++ b/pkg/ctl/topic/stats_internal.go
@@ -85,8 +85,7 @@ func GetInternalStatsCmd(vc *cmdutils.VerbCmd) {
 		"internal-stats",
 		"Get the internal stats of the specified topic",
 		desc.ToString(),
-		desc.ExampleToString(),
-		"")
+		desc.ExampleToString())
 
 	var partition int
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation
Attempt to use built-in bash completion provided by cobra package fails on invalid shell expressions.
During investigation I noticed it is caused by declaring empty strings (`""`) as command aliases. Fortunately, command
aliases are passed as variadic arguments so fix is very simple and doesn't require substantial changes.

### Modifications
* I removed pointless empty ("") aliases as they break bash completion
* I remove aliases that are the same as primary command name
* I aligned `cmdutils.NewResourceCmd` parameters in `test_help.go` to match call parameters in their respective `Command` functions.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
My changes do not modify logic or public command-line interface.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

