### PR TITLE
Add aarch64 as alias for arm64 architecture

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,7 @@ discoverArch() {
     i686) ARCH="386";;
     i386) ARCH="386";;
     arm64) ARCH="arm64";;
+    aarch64) ARCH="arm64";;
   esac
 }
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

When running in a dev-container on Mac Silicon, e.g. in a bookworm image,

Running `uname -m` on host yields **arm64**.

Simple `devcontainer.json` to reproduce:

```json
{
    "name": "PulsarCTL",
    "image": "mcr.microsoft.com/devcontainers/base:bookworm"
}
```

Opening a terminal in the dev-container and running `uname -m` yields `aarch64`.

Running the install.sh script (via `bash` not `sh` and referencing v3.2.2.3 since [current stable/default v3.1.0.2](https://github.com/streamnative/pulsarctl/blob/fff7a08bc108fca0d8b05c2025c872b2a530111e/stable.txt) has no release on `arm64-linux`):

```sh
version=v3.2.2.3 bash -c "$(curl -fsSL https://raw.githubusercontent.com/streamnative/pulsarctl/master/install.sh)"
```

Yields:

```txt
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9  100     9    0     0     42      0 --:--:-- --:--:-- --:--:--    42

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

This is due to script trying to download <https://github.com/streamnative/pulsarctl/releases/download/v3.2.2.3/pulsarctl-aarch64-linux.tar.gz> which should be <https://github.com/streamnative/pulsarctl/releases/download/v3.2.2.3/pulsarctl-arm64-linux.tar.gz>.

### Modifications

Added `aarch64` as alias for `arm64` architecture in `install.sh`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change required Apple Silicon processor to test, but regression is covered by existing tests.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  A bug
  
- [ ] `doc` 
  
  (If this PR contains doc changes)