### PR TITLE
Support load oauth2 configs from auth params

### DIFF
--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -34,3 +34,4 @@ jobs:
           format: 'table'
           exit-code: '1'
           severity: "MEDIUM,HIGH,CRITICAL"
+          vuln-type: "library"

--- a/pkg/ctl/context/create_context_test.go
+++ b/pkg/ctl/context/create_context_test.go
@@ -75,3 +75,47 @@ func TestOauthConfiguration(t *testing.T) {
 	assert.Equal(t, "audience", config.Audience)
 	assert.Equal(t, "profile api://test-endpoint", config.Scope)
 }
+
+func TestParseOauthConfiguration(t *testing.T) {
+	home := utils.HomeDir()
+	path := fmt.Sprintf("%s/.config/pulsar/config", home)
+	defer os.Remove(path)
+
+	setOauthConfigArgs := []string{"set", "oauth",
+		"--auth-params", "{\"audience\":\"audience\",\"issuerUrl\":\"https://test-endpoint\",\"privateKey\":\"/tmp/auth.json\",\"scope\":\"profile api://test-endpoint\",\"clientId\":\"clientid\"}",
+	}
+	_, execErr, err := TestConfigCommands(setContextCmd, setOauthConfigArgs)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	assert.Nil(t, execErr)
+
+	config := cmdutils.LoadFromEnv()
+	assert.Equal(t, "https://test-endpoint", config.IssuerEndpoint)
+	assert.Equal(t, "clientid", config.ClientID)
+	assert.Equal(t, "audience", config.Audience)
+	assert.Equal(t, "profile api://test-endpoint", config.Scope)
+	assert.Equal(t, "/tmp/auth.json", config.KeyFile)
+}
+
+func TestParseWrongFormatOauthConfiguration(t *testing.T) {
+	home := utils.HomeDir()
+	path := fmt.Sprintf("%s/.config/pulsar/config", home)
+	defer os.Remove(path)
+
+	setOauthConfigArgs := []string{"set", "oauth",
+		"--auth-params", "wrong_format",
+	}
+	_, execErr, err := TestConfigCommands(setContextCmd, setOauthConfigArgs)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	assert.Nil(t, execErr)
+
+	config := cmdutils.LoadFromEnv()
+	assert.Equal(t, "", config.IssuerEndpoint)
+	assert.Equal(t, "", config.ClientID)
+	assert.Equal(t, "", config.Audience)
+	assert.Equal(t, "", config.Scope)
+	assert.Equal(t, "", config.KeyFile)
+}

--- a/pkg/ctl/context/create_context_test.go
+++ b/pkg/ctl/context/create_context_test.go
@@ -82,7 +82,9 @@ func TestParseOauthConfiguration(t *testing.T) {
 	defer os.Remove(path)
 
 	setOauthConfigArgs := []string{"set", "oauth",
-		"--auth-params", "{\"audience\":\"audience\",\"issuerUrl\":\"https://test-endpoint\",\"privateKey\":\"/tmp/auth.json\",\"scope\":\"profile api://test-endpoint\",\"clientId\":\"clientid\"}",
+		"--auth-params",
+		"{\"audience\":\"audience\",\"issuerUrl\":\"https://test-endpoint\",\"privateKey\":\"/tmp/auth.json\"," +
+			"\"scope\":\"profile api://test-endpoint\",\"clientId\":\"clientid\"}",
 	}
 	_, execErr, err := TestConfigCommands(setContextCmd, setOauthConfigArgs)
 	if err != nil {


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

Make `context set` command able to parse `--auth-params` directly if it's an oauth2 type params and set oauth2 related configs

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- This change added tests and can be verified as follows:

  - *Added unit tests for handling `--auth-params` in correct format and wrong format`

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

