### PR TITLE
Setup go version to 1.22 fix cve

### DIFF
--- a/.github/workflows/ci-bookie-checks.yml
+++ b/.github/workflows/ci-bookie-checks.yml
@@ -11,10 +11,10 @@ jobs:
   bookie-ut-tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.21
+    - name: Set up Go 1.22
       uses: actions/setup-go@v1
       with:
-        go-version: 1.21
+        go-version: 1.22
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Login SN docker hub
       run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-    - name: Set up Go 1.21
+    - name: Set up Go 1.22
       uses: actions/setup-go@v1
       with:
-        go-version: 1.21
+        go-version: 1.22
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -30,10 +30,10 @@ jobs:
     steps:
       - name: Login SN docker hub
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v1
         with:
-          go-version: 1.21
+          go-version: 1.22
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -44,10 +44,10 @@ jobs:
     steps:
       - name: Login SN docker hub
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v1
         with:
-          go-version: 1.21
+          go-version: 1.22
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-packages-checks.yml
+++ b/.github/workflows/ci-packages-checks.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Login SN docker hub
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v1
         with:
-          go-version: 1.21
+          go-version: 1.22
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -11,10 +11,10 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v1
         with:
-          go-version: 1.21
+          go-version: 1.22
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -12,10 +12,10 @@ jobs:
   scan-vulnerabilities:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v1
         with:
-          go-version: 1.21
+          go-version: 1.22
         id: go
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
### Motivation
Refer to CI: https://github.com/streamnative/pulsarctl/actions/runs/10782833529/job/29903652702?pr=1586

### Modifications
Upgrade go to 1.22


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

