### PR TITLE
feat: Subscription get message by id json output

### DIFF
--- a/pkg/ctl/subscription/get_message_by_id.go
+++ b/pkg/ctl/subscription/get_message_by_id.go
@@ -29,6 +29,13 @@ import (
 	"github.com/streamnative/pulsarctl/pkg/cmdutils"
 )
 
+type readMessage struct {
+	Properties      map[string]string `json:"properties"`
+	MessageId       utils.MessageID   `json:"messageId"`
+	Payload         []byte            `json:"payload"`
+	PayloadAsString string            `json:"PayloadString"`
+}
+
 func GetMessageByIDCmd(vc *cmdutils.VerbCmd) {
 	var desc cmdutils.LongDescription
 	desc.CommandUsedFor = "This command is used for getting messages by the given legerID and entryID" +
@@ -91,27 +98,22 @@ func doGetMessageByID(vc *cmdutils.VerbCmd, legerID int64, entryID int64) error 
 		return err
 	}
 
-	textOutput := fmt.Sprintf(`Message ID: %s
-Properties: %s
-Message: %s`, message.GetMessageID(), propertiesJSON, hex.Dump(message.Payload))
+	textOutput := fmt.Sprintf(
+		`Message ID: %s
+		Properties: %s
+		Message: 
+				%s`, message.GetMessageID(), propertiesJSON, hex.Dump(message.Payload))
 
 	oc := cmdutils.NewOutputContent().
-		WithObject(&ReadMessage{
-			MessageId:     message.GetMessageID(),
-			Properties:    message.GetProperties(),
-			Payload:       message.Payload,
-			PayloadString: string(message.Payload),
+		WithObject(&readMessage{
+			MessageId:       message.GetMessageID(),
+			Properties:      message.GetProperties(),
+			Payload:         message.Payload,
+			PayloadAsString: string(message.Payload),
 		}).
 		WithText(textOutput)
 
 	err = vc.OutputConfig.WriteOutput(vc.Command.OutOrStdout(), oc)
 
 	return err
-}
-
-type ReadMessage struct {
-	Properties    map[string]string `json:"properties"`
-	MessageId     utils.MessageID   `json:"messageId"`
-	Payload       []byte            `json:"payload"`
-	PayloadString string            `json:"PayloadString"`
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

This change is to add a possiblity of JSON output from the `subscription.get_message_by_id` command.


### Motivation

In our organization we suggested our teams to utilize Pulsarctl when investigating or debugging Pulsar topics, subscriotions.

Almost all of our messages are in the end json serialized data, but we have also had a few people utilize only strings as the data within the the byte[] sent to pulsar.

When an issue occurs in a consuming system, where e.g a message is received correctly, but fails to be proccesed in the system it always a guarentee that the consuming code allows the team to investigate the message data. That all depends on how they´ve set up their system.

However we advise to use Pulsarctl as a means to be able to view their messages, maybe copy the message content out to examine it further.

But currently the output of the command is a funky raw text outputted along with a hex.Dump of the []byte. looking like this:
![image](https://github.com/user-attachments/assets/e62d2aaf-6198-4341-97f2-afd682b66790)

In my example the message is very small, but lets say the message had like 50 fields with properties, maybe nested.
The column to the right becomes very big and hard to copy value from without doing some terminal magic and converting.

With this the change a JSON representation of the message - alongside the payload is outputted:
![image](https://github.com/user-attachments/assets/6a3273c2-5f37-4df1-b8f2-6b547b104eee)
We can then copy the entire result (or pipe it to something else), unescape the escaped json from  `PayloadAsString` property and have the JSON content available"

I know that messages can also be something entirely else like a file read from disk to a byte array - like a jpg sent as a byte[].

This with text output looks like this:
![image](https://github.com/user-attachments/assets/ae442c53-d9a0-4b1f-9feb-c98c809e887a)

And with json output looks like this:
![image](https://github.com/user-attachments/assets/2be98c47-79f5-40bf-8319-907ddbad16d6)

### Modifications

*Describe the modifications you've done.*
Add `readMessage` struct
Add usage of WithObject output as wel.

### Verifying this change

I have another PR https://github.com/streamnative/pulsarctl/pull/1699 for the same command fixing a typo.
And this issue https://github.com/streamnative/pulsarctl/issues/1703 for verifying needs some input.

- [ ] Make sure that the change passes the CI checks. 

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

Check the box below.
  
- [x] `no-need-doc` 

