### PR TITLE
Enhance GetStatsCmd to include additional options for backlog statistics

### DIFF
--- a/pkg/ctl/topic/stats_test.go
+++ b/pkg/ctl/topic/stats_test.go
@@ -180,3 +180,150 @@ func TestGetNonPartitionedTopicStatsError(t *testing.T) {
 	assert.NotNil(t, execErr)
 	assert.Contains(t, execErr.Error(), "code: 404 reason: Partitioned Topic")
 }
+
+func TestGetStatsWithPreciseBacklog(t *testing.T) {
+	args := []string{"create", "test-stats-precise-backlog", "0"}
+	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+
+	args = []string{"stats", "--get-precise-backlog", "test-stats-precise-backlog"}
+	out, execErr, _, _ := TestTopicCommands(GetStatsCmd, args)
+	assert.Nil(t, execErr)
+
+	var stats utils.TopicStats
+	err := json.Unmarshal(out.Bytes(), &stats)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, defaultStats, stats)
+}
+
+func TestGetStatsWithoutSubscriptionBacklogSize(t *testing.T) {
+	args := []string{"create", "test-stats-no-subscription-backlog", "0"}
+	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+
+	args = []string{"stats", "--get-subscription-backlog-size=false", "test-stats-no-subscription-backlog"}
+	out, execErr, _, _ := TestTopicCommands(GetStatsCmd, args)
+	assert.Nil(t, execErr)
+
+	var stats utils.TopicStats
+	err := json.Unmarshal(out.Bytes(), &stats)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, defaultStats, stats)
+}
+
+func TestGetStatsWithEarliestTimeInBacklog(t *testing.T) {
+	args := []string{"create", "test-stats-earliest-time-backlog", "0"}
+	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+
+	args = []string{"stats", "--get-earliest-time-in-backlog", "test-stats-earliest-time-backlog"}
+	out, execErr, _, _ := TestTopicCommands(GetStatsCmd, args)
+	assert.Nil(t, execErr)
+
+	var stats utils.TopicStats
+	err := json.Unmarshal(out.Bytes(), &stats)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, defaultStats, stats)
+}
+
+func TestGetStatsWithMultipleNewFlags(t *testing.T) {
+	args := []string{"create", "test-stats-multiple-flags", "0"}
+	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+
+	args = []string{"stats", "--get-precise-backlog", "--get-earliest-time-in-backlog", "test-stats-multiple-flags"}
+	out, execErr, _, _ := TestTopicCommands(GetStatsCmd, args)
+	assert.Nil(t, execErr)
+
+	var stats utils.TopicStats
+	err := json.Unmarshal(out.Bytes(), &stats)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, defaultStats, stats)
+}
+
+func TestGetPartitionedStatsWithNewFlags(t *testing.T) {
+	args := []string{"create", "test-partitioned-stats-new-flags", "2"}
+	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+
+	args = []string{"stats", "--partitioned-topic", "--get-precise-backlog", "test-partitioned-stats-new-flags"}
+	out, execErr, _, _ := TestTopicCommands(GetStatsCmd, args)
+	assert.Nil(t, execErr)
+
+	var stats utils.PartitionedTopicStats
+	err := json.Unmarshal(out.Bytes(), &stats)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, float64(0), stats.MsgRateIn)
+	assert.Equal(t, float64(0), stats.MsgRateOut)
+	assert.Equal(t, float64(0), stats.MsgThroughputIn)
+	assert.Equal(t, float64(0), stats.MsgThroughputOut)
+	assert.Equal(t, float64(0), stats.AverageMsgSize)
+	assert.Equal(t, int64(0), stats.StorageSize)
+	assert.Equal(t, 0, len(stats.Publishers))
+	assert.Equal(t, 0, len(stats.Subscriptions))
+	assert.Equal(t, 0, len(stats.Replication))
+	assert.Equal(t, "", stats.DeDuplicationStatus)
+	assert.Equal(t, 2, stats.Metadata.Partitions)
+	assert.Equal(t, 0, len(stats.Partitions))
+}
+
+func TestGetPerPartitionStatsWithNewFlags(t *testing.T) {
+	args := []string{"create", "test-per-partition-stats-new-flags", "1"}
+	_, execErr, _, _ := TestTopicCommands(CreateTopicCmd, args)
+	assert.Nil(t, execErr)
+
+	args = []string{"stats", "--partitioned-topic", "--per-partition", "--get-earliest-time-in-backlog", "test-per-partition-stats-new-flags"}
+	out, execErr, _, _ := TestTopicCommands(GetStatsCmd, args)
+	assert.Nil(t, execErr)
+
+	var stats utils.PartitionedTopicStats
+	err := json.Unmarshal(out.Bytes(), &stats)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defaultStats := utils.PartitionedTopicStats{
+		MsgRateIn:           0,
+		MsgRateOut:          0,
+		MsgThroughputIn:     0,
+		MsgThroughputOut:    0,
+		AverageMsgSize:      0,
+		StorageSize:         0,
+		Publishers:          []utils.PublisherStats{},
+		Subscriptions:       map[string]utils.SubscriptionStats{},
+		Replication:         map[string]utils.ReplicatorStats{},
+		DeDuplicationStatus: "",
+		Metadata:            utils.PartitionedTopicMetadata{Partitions: 1},
+		Partitions: map[string]utils.TopicStats{
+			"persistent://public/default/test-per-partition-stats-new-flags-partition-0": {
+				MsgRateIn:           0,
+				MsgRateOut:          0,
+				MsgThroughputIn:     0,
+				MsgThroughputOut:    0,
+				AverageMsgSize:      0,
+				StorageSize:         0,
+				Publishers:          []utils.PublisherStats{},
+				Subscriptions:       map[string]utils.SubscriptionStats{},
+				Replication:         map[string]utils.ReplicatorStats{},
+				DeDuplicationStatus: "Disabled",
+			},
+		},
+	}
+
+	assert.Equal(t, defaultStats, stats)
+}


### PR DESCRIPTION
fix https://github.com/streamnative/pulsarctl/issues/1800

- Added flags for precise backlog size, subscription backlog size, and earliest time in backlog.
- Updated doGetStats function to accept new parameters and utilize them in the stats retrieval process.
- Modified calls to GetPartitionedStats and GetStats to use the new options structure.


<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

