### PR TITLE
Fix go cve CVE-2025-22874

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/streamnative/pulsarctl
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/apache/pulsar-client-go v0.14.0


### PR DESCRIPTION

### Motivation

Fix CVE CVE-2025-22874

https://github.com/streamnative/pulsarctl/actions/runs/15816495861/job/44576371357?pr=1816#step:6:280

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

