### PR TITLE
Bump go version to 1.25.9 to fix CVE-2026-32280

### DIFF
--- a/.github/workflows/ci-bookie-checks.yml
+++ b/.github/workflows/ci-bookie-checks.yml
@@ -11,10 +11,10 @@ jobs:
   bookie-ut-tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.25.8
+    - name: Set up Go 1.25.9
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.8
+        go-version: 1.25.9
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -14,10 +14,10 @@ jobs:
     - name: Login SN docker hub
       if: github.actor == 'streamnativebot'
       run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-    - name: Set up Go 1.25.8
+    - name: Set up Go 1.25.9
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.8
+        go-version: 1.25.9
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -34,10 +34,10 @@ jobs:
       - name: Login SN docker hub
         if: github.actor == 'streamnativebot'
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.25.8
+      - name: Set up Go 1.25.9
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -51,10 +51,10 @@ jobs:
       - name: Login SN docker hub
         if: github.actor == 'streamnativebot'
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.25.8
+      - name: Set up Go 1.25.9
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-packages-checks.yml
+++ b/.github/workflows/ci-packages-checks.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Login SN docker hub
         if: github.actor == 'streamnativebot'
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.25.8
+      - name: Set up Go 1.25.9
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-release-checks.yml
+++ b/.github/workflows/ci-release-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.25.8 ]
+        go-version: [ 1.25.9 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -11,10 +11,10 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25.8
+      - name: Set up Go 1.25.9
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -12,10 +12,10 @@ jobs:
   scan-vulnerabilities:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25.8
+      - name: Set up Go 1.25.9
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/streamnative/pulsarctl
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/apache/pulsar-client-go v0.18.0-candidate-1.0.20251222030102-3bb7d4eff361

--- a/scripts/test-docker/Dockerfile
+++ b/scripts/test-docker/Dockerfile
@@ -9,7 +9,7 @@ USER root
 RUN apk update && apk add curl git build-base
 
 # install golang
-COPY --from=golang:1.25.8-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.25.9-alpine /usr/local/go/ /usr/local/go/
 ENV PATH /usr/local/go/bin:$PATH
 
 


### PR DESCRIPTION


### Motivation

https://github.com/streamnative/pulsarctl/actions/runs/24431586681/job/71376977831?pr=2048



<img width="2240" height="954" alt="image" src="https://github.com/user-attachments/assets/2e1dfd7d-6bc6-4729-a4e1-0f5b74a70a2f" />




### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

