### PR TITLE
fix: upgrade Go to 1.25.9 to fix CVE-2026-32281, CVE-2026-32288 in stdlib

### DIFF
--- a/.github/workflows/ci-bookie-checks.yml
+++ b/.github/workflows/ci-bookie-checks.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.25
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25
+        go-version: 1.25.9
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.25
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25
+        go-version: 1.25.9
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go 1.25
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25
+          go-version: 1.25.9
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go 1.25
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25
+          go-version: 1.25.9
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-packages-checks.yml
+++ b/.github/workflows/ci-packages-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.25
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.25.9
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-release-checks.yml
+++ b/.github/workflows/ci-release-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.25 ]
+        go-version: [ 1.25.9 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.25
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.25.9
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.25
         uses: actions/setup-go@v1
         with:
-          go-version: 1.25
+          go-version: 1.25.9
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/streamnative/pulsarctl
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/apache/pulsar-client-go v0.18.0-candidate-1.0.20251222030102-3bb7d4eff361


### PR DESCRIPTION
## Summary

Upgrade Go from `1.25.8` to `1.25.9` in `go.mod` and CI workflows on `branch-4.0` to patch Go stdlib CVEs affecting the `pulsarctl` binary embedded in `sn-platform-slim:4.0.9.6`.

## CVE Details

| CVE ID | Severity | Description | Fixed In |
|--------|----------|-------------|----------|
| CVE-2026-32281 | Medium | `crypto/x509`: DoS via inefficient certificate chain validation with many policy mappings | Go 1.25.9 / 1.26.2 |
| CVE-2026-32288 | Medium | Additional Go stdlib vulnerability | Go 1.25.9 / 1.26.2 |

- **NVD Link**: https://nvd.nist.gov/vuln/detail/CVE-2026-32281
- **Affected Package**: `stdlib@v1.25.8` (compiled into `pulsar/bin/pulsarctl` binary in sn-platform-slim)

## How the CVE Was Introduced

The `pulsarctl` binary in `sn-platform-slim:4.0.9.6` at `pulsar/bin/pulsarctl` was compiled with Go 1.25.8, which embeds the vulnerable stdlib.

```
sn-platform-slim:4.0.9.6
└── pulsar/bin/pulsarctl ← compiled with stdlib@v1.25.8 (Vulnerable)
    └── go.mod: go 1.25.8 → builds with vulnerable crypto/x509
```

## Why This Fix Resolves the CVEs

- Pinning Go to `1.25.9` ensures the `pulsarctl` binary is compiled with the patched stdlib
- Go 1.25.9 fixes the `crypto/x509` inefficient policy chain validation (CVE-2026-32281)

## Changes Made

- `go.mod`: `go 1.25.8` → `go 1.25.9`
- `.github/workflows/ci-style-checks.yml`: `1.25` → `1.25.9`
- `.github/workflows/ci-functions-checks.yml`: `1.25` → `1.25.9`
- `.github/workflows/ci-packages-checks.yml`: `1.25` → `1.25.9`
- `.github/workflows/ci-bookie-checks.yml`: `1.25` → `1.25.9`
- `.github/workflows/ci-release-checks.yml`: `1.25` → `1.25.9`
- `.github/workflows/ci-trivy.yml`: `1.25` → `1.25.9`

## Verification

- [x] `go.mod` updated to `go 1.25.9`
- [x] CI workflows updated to pin Go `1.25.9`

Closes #4298