### PR TITLE
Bump to 4.3.0-SNAPSHOT and ensure java is on PATH

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -5,6 +5,31 @@ set -e
 readonly PULSARCTL_HOME=${PULSARCTL_HOME:-"/pulsarctl"}
 readonly TEST_ARGS=${TEST_ARGS:-""}
 
+function ensureJavaInPath() {
+    if command -v java >/dev/null 2>&1; then
+        return
+    fi
+
+    for dir in \
+        /opt/jvm/bin \
+        /opt/java/openjdk/bin \
+        /usr/local/openjdk-17/bin \
+        /usr/local/openjdk-11/bin \
+        /usr/lib/jvm/default-jvm/bin \
+        /usr/lib/jvm/java-17-openjdk/bin \
+        /usr/lib/jvm/java-11-openjdk/bin
+    do
+        if [[ -x "${dir}/java" ]]; then
+            export PATH="${dir}:${PATH}"
+            export JAVA_HOME="${dir%/bin}"
+            return
+        fi
+    done
+
+    echo "java executable not found in PATH or common JDK locations"
+    exit 1
+}
+
 function checkFunctionWorker() {
     failed=0
     until curl --silent localhost:8080/admin/v2/persistent/public/functions/coordinate/stats; do
@@ -20,6 +45,7 @@ function checkFunctionWorker() {
 }
 
 pushd ${PULSARCTL_HOME}
+ensureJavaInPath
 # startup pulsar service
 scripts/pulsar-service-startup.sh
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -3,7 +3,7 @@ set -e
 
 readonly PROJECT_ROOT=`cd $(dirname $0)/..; pwd`
 readonly IMAGE_NAME=pulsarctl-test
-readonly PULSAR_DEFAULT_VERSION="4.1.3"
+readonly PULSAR_DEFAULT_VERSION="4.3.0-SNAPSHOT"
 readonly PULSAR_VERSION=${PULSAR_VERSION:-${PULSAR_DEFAULT_VERSION}}
 readonly PULSAR_IMAGE=${PULSAR_IMAGE:-"apachepulsar/pulsar-all"}
 


### PR DESCRIPTION
## Summary
- include the 4.3.0-SNAPSHOT version bump from 93d0414
- add a small PATH/JAVA_HOME fallback in the integration test entrypoint
- keep this PR scoped to the version bump plus the JDK fix only

## Testing
- validated that /opt/jvm/bin/java exists in snstage/pulsar-all:4.3.0-SNAPSHOT
- validated the entrypoint script with bash -n
- observed sink/source integration failures move past the previous "java not found" error after this fix