### PR TITLE
Add JDK path 

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -5,6 +5,31 @@ set -e
 readonly PULSARCTL_HOME=${PULSARCTL_HOME:-"/pulsarctl"}
 readonly TEST_ARGS=${TEST_ARGS:-""}
 
+function ensureJavaInPath() {
+    if command -v java >/dev/null 2>&1; then
+        return
+    fi
+
+    for dir in \
+        /opt/jvm/bin \
+        /opt/java/openjdk/bin \
+        /usr/local/openjdk-17/bin \
+        /usr/local/openjdk-11/bin \
+        /usr/lib/jvm/default-jvm/bin \
+        /usr/lib/jvm/java-17-openjdk/bin \
+        /usr/lib/jvm/java-11-openjdk/bin
+    do
+        if [[ -x "${dir}/java" ]]; then
+            export PATH="${dir}:${PATH}"
+            export JAVA_HOME="${dir%/bin}"
+            return
+        fi
+    done
+
+    echo "java executable not found in PATH or common JDK locations"
+    exit 1
+}
+
 function checkFunctionWorker() {
     failed=0
     until curl --silent localhost:8080/admin/v2/persistent/public/functions/coordinate/stats; do
@@ -20,6 +45,7 @@ function checkFunctionWorker() {
 }
 
 pushd ${PULSARCTL_HOME}
+ensureJavaInPath
 # startup pulsar service
 scripts/pulsar-service-startup.sh
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -3,7 +3,7 @@ set -e
 
 readonly PROJECT_ROOT=`cd $(dirname $0)/..; pwd`
 readonly IMAGE_NAME=pulsarctl-test
-readonly PULSAR_DEFAULT_VERSION="4.1.3"
+readonly PULSAR_DEFAULT_VERSION="4.3.0-SNAPSHOT"
 readonly PULSAR_VERSION=${PULSAR_VERSION:-${PULSAR_DEFAULT_VERSION}}
 readonly PULSAR_IMAGE=${PULSAR_IMAGE:-"apachepulsar/pulsar-all"}
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -3,7 +3,7 @@ set -e
 
 readonly PROJECT_ROOT=`cd $(dirname $0)/..; pwd`
 readonly IMAGE_NAME=pulsarctl-test
-readonly PULSAR_DEFAULT_VERSION="4.3.0-SNAPSHOT"
+readonly PULSAR_DEFAULT_VERSION="4.1.3"
 readonly PULSAR_VERSION=${PULSAR_VERSION:-${PULSAR_DEFAULT_VERSION}}
 readonly PULSAR_IMAGE=${PULSAR_IMAGE:-"apachepulsar/pulsar-all"}
 


### PR DESCRIPTION
### Motivation

```
=== RUN   TestSinksOperations
    opeations_test.go:107: last sink status before timeout: {
          "numInstances": 1,
          "numRunning": 0,
          "instances": [
            {
              "instanceId": 0,
              "status": {
                "running": false,
                "error": "Cannot run program \"java\": Exec failed, error: 2 (No such file or directory) ",
                "numRestarts": 5,
                "numReadFromPulsar": 0,
                "numSystemExceptions": 0,
                "latestSystemExceptions": [],
                "numSinkExceptions": 0,
                "latestSinkExceptions": [],
                "numWrittenToSink": 0,
                "lastReceivedTime": 0,
                "workerId": "c-standalone-fw-50f128fd8221-8080"
              }
            }
          ]
        }
    test_help.go:76: /pulsarctl/pkg/ctl/sinks/opeations_test.go 109 task timeout

```


See here, https://github.com/streamnative/pulsarctl/pull/2065

the new jdk path has changed, so we need to add the path to ensure the container startup

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

