### PR TITLE
Bump go version to 1.25.10 to fix CVE

### DIFF
--- a/.github/workflows/ci-bookie-checks.yml
+++ b/.github/workflows/ci-bookie-checks.yml
@@ -14,11 +14,7 @@ jobs:
     - name: Set up Go 1.25.9
       uses: actions/setup-go@v6
       with:
-<<<<<<< Updated upstream
-        go-version: 1.25.9
-=======
         go-version: 1.25.10
->>>>>>> Stashed changes
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/ci-bookie-checks.yml
+++ b/.github/workflows/ci-bookie-checks.yml
@@ -14,7 +14,11 @@ jobs:
     - name: Set up Go 1.25.9
       uses: actions/setup-go@v6
       with:
+<<<<<<< Updated upstream
         go-version: 1.25.9
+=======
+        go-version: 1.25.10
+>>>>>>> Stashed changes
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -17,11 +17,7 @@ jobs:
     - name: Set up Go 1.25.9
       uses: actions/setup-go@v6
       with:
-<<<<<<< Updated upstream
-        go-version: 1.25.9
-=======
         go-version: 1.25.10
->>>>>>> Stashed changes
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -41,11 +37,7 @@ jobs:
       - name: Set up Go 1.25.9
         uses: actions/setup-go@v6
         with:
-<<<<<<< Updated upstream
-          go-version: 1.25.9
-=======
           go-version: 1.25.10
->>>>>>> Stashed changes
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -62,11 +54,7 @@ jobs:
       - name: Set up Go 1.25.9
         uses: actions/setup-go@v6
         with:
-<<<<<<< Updated upstream
-          go-version: 1.25.9
-=======
           go-version: 1.25.10
->>>>>>> Stashed changes
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -17,7 +17,11 @@ jobs:
     - name: Set up Go 1.25.9
       uses: actions/setup-go@v6
       with:
+<<<<<<< Updated upstream
         go-version: 1.25.9
+=======
+        go-version: 1.25.10
+>>>>>>> Stashed changes
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -37,7 +41,11 @@ jobs:
       - name: Set up Go 1.25.9
         uses: actions/setup-go@v6
         with:
+<<<<<<< Updated upstream
           go-version: 1.25.9
+=======
+          go-version: 1.25.10
+>>>>>>> Stashed changes
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -54,7 +62,11 @@ jobs:
       - name: Set up Go 1.25.9
         uses: actions/setup-go@v6
         with:
+<<<<<<< Updated upstream
           go-version: 1.25.9
+=======
+          go-version: 1.25.10
+>>>>>>> Stashed changes
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-packages-checks.yml
+++ b/.github/workflows/ci-packages-checks.yml
@@ -17,7 +17,11 @@ jobs:
       - name: Set up Go 1.25.9
         uses: actions/setup-go@v5
         with:
+<<<<<<< Updated upstream
           go-version: 1.25.9
+=======
+          go-version: 1.25.10
+>>>>>>> Stashed changes
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-packages-checks.yml
+++ b/.github/workflows/ci-packages-checks.yml
@@ -17,11 +17,7 @@ jobs:
       - name: Set up Go 1.25.9
         uses: actions/setup-go@v5
         with:
-<<<<<<< Updated upstream
-          go-version: 1.25.9
-=======
           go-version: 1.25.10
->>>>>>> Stashed changes
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-release-checks.yml
+++ b/.github/workflows/ci-release-checks.yml
@@ -14,11 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-<<<<<<< Updated upstream
-        go-version: [ 1.25.9 ]
-=======
         go-version: [ 1.25.10 ]
->>>>>>> Stashed changes
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci-release-checks.yml
+++ b/.github/workflows/ci-release-checks.yml
@@ -14,7 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+<<<<<<< Updated upstream
         go-version: [ 1.25.9 ]
+=======
+        go-version: [ 1.25.10 ]
+>>>>>>> Stashed changes
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -14,7 +14,11 @@ jobs:
       - name: Set up Go 1.25.9
         uses: actions/setup-go@v5
         with:
+<<<<<<< Updated upstream
           go-version: 1.25.9
+=======
+          go-version: 1.25.10
+>>>>>>> Stashed changes
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -14,11 +14,7 @@ jobs:
       - name: Set up Go 1.25.9
         uses: actions/setup-go@v5
         with:
-<<<<<<< Updated upstream
-          go-version: 1.25.9
-=======
           go-version: 1.25.10
->>>>>>> Stashed changes
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -15,7 +15,11 @@ jobs:
       - name: Set up Go 1.25.9
         uses: actions/setup-go@v5
         with:
+<<<<<<< Updated upstream
           go-version: 1.25.9
+=======
+          go-version: 1.25.10
+>>>>>>> Stashed changes
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -15,11 +15,7 @@ jobs:
       - name: Set up Go 1.25.9
         uses: actions/setup-go@v5
         with:
-<<<<<<< Updated upstream
-          go-version: 1.25.9
-=======
           go-version: 1.25.10
->>>>>>> Stashed changes
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/streamnative/pulsarctl
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/apache/pulsar-client-go v0.18.0-candidate-1.0.20251222030102-3bb7d4eff361

--- a/scripts/test-docker/Dockerfile
+++ b/scripts/test-docker/Dockerfile
@@ -9,11 +9,7 @@ USER root
 RUN apk update && apk add curl git build-base
 
 # install golang
-<<<<<<< Updated upstream
-COPY --from=golang:1.25.9-alpine /usr/local/go/ /usr/local/go/
-=======
 COPY --from=golang:1.25.10-alpine /usr/local/go/ /usr/local/go/
->>>>>>> Stashed changes
 ENV PATH /usr/local/go/bin:$PATH
 
 

--- a/scripts/test-docker/Dockerfile
+++ b/scripts/test-docker/Dockerfile
@@ -9,7 +9,11 @@ USER root
 RUN apk update && apk add curl git build-base
 
 # install golang
+<<<<<<< Updated upstream
 COPY --from=golang:1.25.9-alpine /usr/local/go/ /usr/local/go/
+=======
+COPY --from=golang:1.25.10-alpine /usr/local/go/ /usr/local/go/
+>>>>>>> Stashed changes
 ENV PATH /usr/local/go/bin:$PATH
 
 


### PR DESCRIPTION

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

