### PR TITLE
[fix][sec] Update branch-4.0 Go toolchain

### DIFF
--- a/.github/workflows/ci-bookie-checks.yml
+++ b/.github/workflows/ci-bookie-checks.yml
@@ -11,10 +11,10 @@ jobs:
   bookie-ut-tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.25
+    - name: Set up Go 1.26.4
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.9
+        go-version: 1.26.4
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Login SN docker hub
       run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-    - name: Set up Go 1.25
+    - name: Set up Go 1.26.4
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.9
+        go-version: 1.26.4
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -30,10 +30,10 @@ jobs:
     steps:
       - name: Login SN docker hub
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26.4
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.9
+          go-version: 1.26.4
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -44,10 +44,10 @@ jobs:
     steps:
       - name: Login SN docker hub
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26.4
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.9
+          go-version: 1.26.4
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-packages-checks.yml
+++ b/.github/workflows/ci-packages-checks.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Login SN docker hub
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26.4
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.9
+          go-version: 1.26.4
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-release-checks.yml
+++ b/.github/workflows/ci-release-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.25.9 ]
+        go-version: [ 1.26.4 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -11,10 +11,10 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26.4
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.9
+          go-version: 1.26.4
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -12,10 +12,10 @@ jobs:
   scan-vulnerabilities:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26.4
         uses: actions/setup-go@v1
         with:
-          go-version: 1.25.9
+          go-version: 1.26.4
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.26.4'
 
       - name: Get the version
         id: get_version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/streamnative/pulsarctl
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/apache/pulsar-client-go v0.18.0-candidate-1.0.20251222030102-3bb7d4eff361


### PR DESCRIPTION
### Motivation
Fix the pulsarctl:4.0.10.4 Go stdlib CVE ticket.

Covered ticket: streamnative/eng-support-tickets#4590.

### Changes
- Update go.mod to Go 1.26.4.
- Update CI and release workflow setup-go versions to 1.26.4.

### Verification
- GOTOOLCHAIN=auto go test ./... -run ^$

Note: a full `GOTOOLCHAIN=auto go test ./...` was also attempted; it reached runtime/integration tests that require local Pulsar/BookKeeper/Docker resources and failed on connection/environment setup, not compilation.
