### PR TITLE
fix: bump Go to 1.25.11 to fix CVE-2026-42504 and CVE-2026-33811

### DIFF
--- a/.github/workflows/ci-bookie-checks.yml
+++ b/.github/workflows/ci-bookie-checks.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.25.8
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.10
+        go-version: 1.25.11
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.25.8
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.10
+        go-version: 1.25.11
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go 1.25.8
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.10
+          go-version: 1.25.11
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go 1.25.8
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.10
+          go-version: 1.25.11
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-packages-checks.yml
+++ b/.github/workflows/ci-packages-checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go 1.25.8
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.10
+          go-version: 1.25.11
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-release-checks.yml
+++ b/.github/workflows/ci-release-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.25.10 ]
+        go-version: [ 1.25.11 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.25.8
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.10
+          go-version: 1.25.11
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -12,10 +12,10 @@ jobs:
   scan-vulnerabilities:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25.8
+      - name: Set up Go 1.25.11
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.10
+          go-version: 1.25.11
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/streamnative/pulsarctl
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/apache/pulsar-client-go v0.18.0-candidate-1.0.20251222030102-3bb7d4eff361

--- a/scripts/test-docker/Dockerfile
+++ b/scripts/test-docker/Dockerfile
@@ -9,7 +9,7 @@ USER root
 RUN apk update && apk add curl git build-base
 
 # install golang
-COPY --from=golang:1.25.10-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.25.11-alpine /usr/local/go/ /usr/local/go/
 ENV PATH /usr/local/go/bin:$PATH
 
 


### PR DESCRIPTION
## Summary

- Upgrades Go stdlib from 1.25.10 to 1.25.11 across all CI workflows, `go.mod`, and test Dockerfile
- Fixes CVE-2026-42504 (HIGH): DoS via maliciously-crafted MIME header with many parameters (fixed in 1.25.11)
- Fixes CVE-2026-33811 (HIGH): net package DoS via long host names (fixed in 1.25.10, present in pulsarctl-kube binary still at 1.25.9)

These vulnerabilities were detected by Trivy in `sn-platform-slim:4.2.1.1`:
- `pulsar/bin/pulsarctl` compiled with stdlib v1.25.10, vulnerable to CVE-2026-42504
- `pulsar/plugins/pulsarctl-kube` compiled with stdlib v1.25.9, vulnerable to CVE-2026-33811

## Files changed

- `go.mod`: bumped `go` directive from 1.25.10 to 1.25.11
- `.github/workflows/ci-*.yml`: updated `go-version` from 1.25.10 to 1.25.11
- `scripts/test-docker/Dockerfile`: updated base image from `golang:1.25.10-alpine` to `golang:1.25.11-alpine`

## Related Issues

- Fixes streamnative/eng-support-tickets#4626
- Fixes streamnative/eng-support-tickets#4627

## Test plan

- [ ] CI Trivy scan passes with no HIGH/CRITICAL stdlib CVEs after build
- [ ] All existing CI checks pass on branch-4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)