### PR TITLE
fix: upgrade Go to 1.25.14 and x/sys for CVEs

### DIFF
--- a/.github/workflows/ci-bookie-checks.yml
+++ b/.github/workflows/ci-bookie-checks.yml
@@ -11,10 +11,10 @@ jobs:
   bookie-ut-tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.25.12
+    - name: Set up Go 1.25.14
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.12
+        go-version: 1.25.14
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -14,10 +14,10 @@ jobs:
     - name: Login SN docker hub
       if: github.actor == 'streamnativebot'
       run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-    - name: Set up Go 1.25.12
+    - name: Set up Go 1.25.14
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.12
+        go-version: 1.25.14
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -34,10 +34,10 @@ jobs:
       - name: Login SN docker hub
         if: github.actor == 'streamnativebot'
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.25.12
+      - name: Set up Go 1.25.14
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.12
+          go-version: 1.25.14
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -51,10 +51,10 @@ jobs:
       - name: Login SN docker hub
         if: github.actor == 'streamnativebot'
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.25.12
+      - name: Set up Go 1.25.14
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.12
+          go-version: 1.25.14
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-packages-checks.yml
+++ b/.github/workflows/ci-packages-checks.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Login SN docker hub
         if: github.actor == 'streamnativebot'
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD}}"
-      - name: Set up Go 1.25.12
+      - name: Set up Go 1.25.14
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.12
+          go-version: 1.25.14
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-release-checks.yml
+++ b/.github/workflows/ci-release-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.25.12 ]
+        go-version: [ 1.25.14 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -11,10 +11,10 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25.12
+      - name: Set up Go 1.25.14
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.12
+          go-version: 1.25.14
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -12,10 +12,10 @@ jobs:
   scan-vulnerabilities:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25.12
+      - name: Set up Go 1.25.14
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.12
+          go-version: 1.25.14
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/streamnative/pulsarctl
 
-go 1.25.12
+go 1.25.14
 
 require (
 	github.com/apache/pulsar-client-go v0.18.0-candidate-1.0.20251222030102-3bb7d4eff361
@@ -93,7 +93,7 @@ require (
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251222181119-0a764e51fe1b // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251222181119-0a764e51fe1b // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
-golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.38.0 h1:PQ5pkm/rLO6HnxFR7N2lJHOZX6Kez5Y1gDSJla6jo7Q=
 golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Addresses the 9 findings Trivy reports against `bin/pulsarctl` in the
`sn-platform:4.0.12.3` image. Follows the same pattern as #2119.

| Change | Clears |
|---|---|
| Go **1.25.12 → 1.25.14** (8 `go-version` pins + `go` directive) | 8 stdlib CVEs |
| `golang.org/x/sys` **0.39.0 → 0.44.0** | CVE-2026-39824 |

Eight of the nine are Go stdlib (CVE-2026-33818, CVE-2026-39821, CVE-2026-46600,
CVE-2026-56853, CVE-2026-56858, CVE-2026-56859, CVE-2026-56860, CVE-2026-56862)
and come from the toolchain the binary is built with rather than any module, so
the fix is the version pins. It landed in 1.25.13; staying on the 1.25 line
avoids a language-version jump.

The ninth, CVE-2026-39824, is an integer overflow in `NewNTUnicodeString`, fixed
by x/sys 0.44.0.

The `go.mod` diff is just those two lines — x/sys 0.44.0 satisfies the module
graph, so nothing else was dragged forward.

## Targeting

Opened against `master` since release branches here are cut per platform release
(`branch-4.0.12.3` is what produced the scanned binary), so this flows into the
next cut. Happy to also patch a release branch directly if a 4.0.12.x respin
needs it sooner.

## Verification

`go build ./...` clean. `go vet ./...` reports one **pre-existing** finding in
`pkg/test/pulsar/standalone_test.go` ("using resp before checking for errors")
that is unrelated to these upgrades and left alone.

## Related

Companion PRs covering the rest of the image:
- streamnative/streamnative-bom#588 / #589 / #590 — BOM-managed Java deps
- streamnative/sn-pulsar-plugins#2719 / #2720 / #2721 — `pulsar-detector`,
  `pulsarctl-kube`, `bookie-rackinfo`
