### PR TITLE
fix: upgrade Go to 1.25.14 and x/sys for CVEs [branch-4.2]

### DIFF
--- a/.github/workflows/ci-bookie-checks.yml
+++ b/.github/workflows/ci-bookie-checks.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.25.8
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.11
+        go-version: 1.25.14
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/ci-functions-checks.yml
+++ b/.github/workflows/ci-functions-checks.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.25.8
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.11
+        go-version: 1.25.14
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go 1.25.8
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.11
+          go-version: 1.25.14
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go 1.25.8
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.11
+          go-version: 1.25.14
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-packages-checks.yml
+++ b/.github/workflows/ci-packages-checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go 1.25.8
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.11
+          go-version: 1.25.14
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-release-checks.yml
+++ b/.github/workflows/ci-release-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.25.11 ]
+        go-version: [ 1.25.14 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.25.8
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.11
+          go-version: 1.25.14
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -12,10 +12,10 @@ jobs:
   scan-vulnerabilities:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25.11
+      - name: Set up Go 1.25.14
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.11
+          go-version: 1.25.14
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/streamnative/pulsarctl
 
-go 1.25.11
+go 1.25.14
 
 require (
 	github.com/apache/pulsar-client-go v0.18.0-candidate-1.0.20251222030102-3bb7d4eff361
@@ -93,7 +93,7 @@ require (
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251222181119-0a764e51fe1b // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251222181119-0a764e51fe1b // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
-golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.38.0 h1:PQ5pkm/rLO6HnxFR7N2lJHOZX6Kez5Y1gDSJla6jo7Q=
 golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Backport of #2133 to `branch-4.2`. Companion to
streamnative/sn-pulsar-plugins#2720 and streamnative/streamnative-bom#589.

| Change | Clears |
|---|---|
| Go **1.25.11 → 1.25.14** (all pins + `go` directive) | 8 stdlib CVEs |
| `golang.org/x/sys` **0.39.0 → 0.44.0** | CVE-2026-39824 |

Same shape as the prior CVE bump on this branch (#2101). The stdlib fix landed
in 1.25.13; staying on the 1.25 line this branch already uses. Unlike
branch-4.0 there is no `release.yml` here, so the CI workflow pins are the
complete set.

`go.mod` diff is exactly two lines. Builds clean; `go vet` shows only the same
pre-existing `standalone_test.go` finding as master.

Same fix in flight: #2133 (master), branch-4.0 PR.
